### PR TITLE
Update game mode visuals and redesign 2-player score bar

### DIFF
--- a/frontend/src/app/features/board/board.css
+++ b/frontend/src/app/features/board/board.css
@@ -21,103 +21,158 @@
   box-shadow: 0 0 8px rgba(204, 255, 0, 0.3);
 }
 
-.board-score-card {
-  border: 1px solid transparent;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+/* Score bar layout */
+.board-scorebar {
+  display: flex;
+  align-items: stretch;
 }
 
+.board-score-card {
+  position: relative;
+  border: 1px solid transparent;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+/* Turn indicator strip at top of card */
+.board-turn-strip {
+  height: 3px;
+  width: 100%;
+}
+
+.board-turn-strip--p1 {
+  background: linear-gradient(90deg, #3b82f6, #60a5fa);
+  box-shadow: 0 0 12px rgba(59, 130, 246, 0.6);
+}
+
+.board-turn-strip--p2 {
+  background: linear-gradient(90deg, #ef4444, #f87171);
+  box-shadow: 0 0 12px rgba(239, 68, 68, 0.6);
+}
+
+/* Player 1 card */
 .board-score-card--p1 {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(37, 99, 235, 0.1) 100%);
-  border-color: rgba(59, 130, 246, 0.3);
+  background: rgba(59, 130, 246, 0.08);
+  border-color: rgba(59, 130, 246, 0.2);
 }
 
 .board-score-card--p1.active {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25) 0%, rgba(37, 99, 235, 0.2) 100%);
-  border-color: rgba(59, 130, 246, 0.6);
+  background: rgba(59, 130, 246, 0.15);
+  border-color: rgba(59, 130, 246, 0.5);
   box-shadow:
-    0 0 0 2px rgba(59, 130, 246, 0.2),
-    0 4px 16px rgba(59, 130, 246, 0.25);
+    0 0 0 1px rgba(59, 130, 246, 0.3),
+    0 8px 24px rgba(59, 130, 246, 0.2);
 }
 
+/* Player 2 card */
 .board-score-card--p2 {
-  background: linear-gradient(135deg, rgba(239, 68, 68, 0.15) 0%, rgba(220, 38, 38, 0.1) 100%);
-  border-color: rgba(239, 68, 68, 0.3);
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.2);
 }
 
 .board-score-card--p2.active {
-  background: linear-gradient(135deg, rgba(239, 68, 68, 0.25) 0%, rgba(220, 38, 38, 0.2) 100%);
-  border-color: rgba(239, 68, 68, 0.6);
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.5);
   box-shadow:
-    0 0 0 2px rgba(239, 68, 68, 0.2),
-    0 4px 16px rgba(239, 68, 68, 0.25);
+    0 0 0 1px rgba(239, 68, 68, 0.3),
+    0 8px 24px rgba(239, 68, 68, 0.2);
 }
 
-.board-player-name {
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
+/* Player names */
 .board-player-name--p1 { color: #60a5fa; }
 .board-player-name--p2 { color: #f87171; }
 
+/* Turn badge */
+.board-turn-badge {
+  letter-spacing: 0.05em;
+}
+
+.board-turn-badge--p1 {
+  background: rgba(59, 130, 246, 0.3);
+  color: #93c5fd;
+}
+
+.board-turn-badge--p2 {
+  background: rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+}
+
+/* Score display */
 .board-score {
   color: var(--color-foreground);
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  line-height: 1;
 }
 
-.board-pill {
-  background: rgba(255, 255, 255, 0.1);
+/* Power-ups */
+.board-powerup {
+  background: rgba(255, 255, 255, 0.08);
   color: var(--color-muted-foreground);
-  font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.board-stat-pill {
-  background: rgba(204, 255, 0, 0.1);
+.board-powerup--used {
+  opacity: 0.4;
+  text-decoration: line-through;
+}
+
+.board-powerup-armed {
+  background: rgba(204, 255, 0, 0.2);
   color: var(--color-accent);
-  font-weight: 600;
+  border: 1px solid rgba(204, 255, 0, 0.4);
+  animation: pulse-glow 1.5s ease-in-out infinite;
 }
 
-.board-double-btn {
+@keyframes pulse-glow {
+  0%, 100% { box-shadow: 0 0 4px rgba(204, 255, 0, 0.3); }
+  50% { box-shadow: 0 0 12px rgba(204, 255, 0, 0.6); }
+}
+
+.board-use-double {
   background: transparent;
   border: 1px solid var(--color-accent);
   color: var(--color-accent);
 }
 
-.board-double-btn:hover {
-  background: rgba(204, 255, 0, 0.1);
+.board-use-double:hover {
+  background: rgba(204, 255, 0, 0.15);
 }
 
-.board-turn-center {
-  min-width: 4.5rem;
+/* Stats */
+.board-stat {
+  color: var(--color-muted-foreground);
 }
 
-.board-turn-label {
-  font-size: 0.625rem;
+.board-stat::before {
+  content: '';
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  background: var(--color-accent);
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
 }
 
-.board-turn-name {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+/* VS divider */
+.board-vs-divider {
+  min-width: 2.5rem;
+  flex-shrink: 0;
 }
 
-.board-turn-name--p1 {
-  background: linear-gradient(135deg, #3b82f6, #2563eb);
-  color: white;
-}
-
-.board-turn-name--p2 {
-  background: linear-gradient(135deg, #ef4444, #dc2626);
-  color: white;
+.board-vs {
+  opacity: 0.5;
 }
 
 .board-end-btn {
-  background: transparent;
-  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   color: var(--color-muted-foreground);
 }
 
 .board-end-btn:hover {
-  border-color: var(--color-loss);
-  color: var(--color-loss);
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #f87171;
 }
 
 .board-category-row {

--- a/frontend/src/app/features/board/board.html
+++ b/frontend/src/app/features/board/board.html
@@ -16,66 +16,105 @@
   </div>
 
   <!-- Score bar -->
-  <div class="flex items-stretch justify-between mb-4 gap-2">
+  <div class="board-scorebar flex items-stretch gap-3 mb-4">
     <!-- Player 1 Score Card -->
-    <div [class]="'board-score-card board-score-card--p1 flex-1 rounded-xl p-3 text-center transition-all ' + scoreCardClass(0)">
-      <div class="board-player-name board-player-name--p1 text-xs font-bold mb-1">{{ players()[0]?.name }}</div>
-      <div class="board-score text-2xl font-black">{{ players()[0]?.score ?? 0 }}</div>
-      <div class="flex flex-wrap justify-center gap-1 mt-1.5">
-        <span [class]="'board-pill text-xs px-1.5 py-0.5 rounded ' + (players()[0]?.lifelineUsed ? 'opacity-40 line-through' : '')">50/50</span>
-        <span [class]="'board-pill text-xs px-1.5 py-0.5 rounded ' + (players()[0]?.doubleUsed ? 'opacity-40 line-through' : '')">2x</span>
-      </div>
-      @if (store.currentStreak()[0] > 0 || store.totalAnswered()[0] > 0) {
-        <div class="flex flex-wrap justify-center gap-1 mt-1.5">
-          @if (store.currentStreak()[0] > 0) {
-            <span class="board-stat-pill text-xs px-1.5 py-0.5 rounded-full">{{ store.currentStreak()[0] }} streak</span>
-          }
-          @if (store.totalAnswered()[0] > 0) {
-            <span class="board-stat-pill text-xs px-1.5 py-0.5 rounded-full">{{ store.accuracy()[0] }}%</span>
+    <div [class]="'board-score-card board-score-card--p1 flex-1 rounded-2xl overflow-hidden transition-all ' + scoreCardClass(0)">
+      <!-- Turn indicator strip -->
+      @if (isActivePlayer(0)) {
+        <div class="board-turn-strip board-turn-strip--p1"></div>
+      }
+      <div class="p-4">
+        <!-- Header: Name + Turn badge -->
+        <div class="flex items-center justify-between mb-2">
+          <span class="board-player-name board-player-name--p1 text-sm font-bold uppercase tracking-wide">{{ players()[0]?.name }}</span>
+          @if (isActivePlayer(0)) {
+            <span class="board-turn-badge board-turn-badge--p1 text-[10px] font-bold uppercase px-2 py-0.5 rounded">{{ lang.t().turn }}</span>
           }
         </div>
-      }
-      @if (isActivePlayer(0) && !players()[0]?.doubleUsed) {
-        @if (store.doubleArmed()) {
-          <div class="mt-1.5 text-xs font-bold text-win">2x ARMED</div>
-        } @else {
-          <button (click)="armDouble()" class="board-double-btn mt-1.5 w-full py-1 rounded-lg text-xs font-bold transition pressable">{{ lang.t().use2x }}</button>
+        
+        <!-- Score -->
+        <div class="board-score text-4xl font-black mb-3">{{ players()[0]?.score ?? 0 }}</div>
+        
+        <!-- Power-ups row -->
+        <div class="flex items-center gap-2 mb-2">
+          <span [class]="'board-powerup text-xs font-semibold px-2 py-1 rounded-md ' + (players()[0]?.lifelineUsed ? 'board-powerup--used' : '')">50/50</span>
+          <span [class]="'board-powerup text-xs font-semibold px-2 py-1 rounded-md ' + (players()[0]?.doubleUsed ? 'board-powerup--used' : '')">2x</span>
+          @if (isActivePlayer(0) && !players()[0]?.doubleUsed) {
+            @if (store.doubleArmed()) {
+              <span class="board-powerup-armed text-xs font-bold px-2 py-1 rounded-md">2x ARMED</span>
+            } @else {
+              <button (click)="armDouble()" class="board-use-double text-xs font-bold px-2 py-1 rounded-md transition pressable">{{ lang.t().use2x }}</button>
+            }
+          }
+        </div>
+        
+        <!-- Stats row -->
+        @if (store.currentStreak()[0] > 0 || store.totalAnswered()[0] > 0) {
+          <div class="flex items-center gap-2">
+            @if (store.currentStreak()[0] > 0) {
+              <span class="board-stat text-xs font-medium">{{ store.currentStreak()[0] }} streak</span>
+            }
+            @if (store.totalAnswered()[0] > 0) {
+              <span class="board-stat text-xs font-medium">{{ store.accuracy()[0] }}%</span>
+            }
+          </div>
         }
-      }
+      </div>
     </div>
 
-    <!-- Center: Turn Indicator -->
-    <div class="board-turn-center flex flex-col items-center justify-center px-1">
-      <div class="board-turn-label text-muted-foreground text-xs mb-1 font-semibold uppercase tracking-wider">{{ lang.t().turn }}</div>
-      <div [class]="'board-turn-name text-xs font-bold px-2.5 py-1.5 rounded-lg whitespace-nowrap ' + turnIndicatorClass()">{{ currentPlayer()?.name }}</div>
-      <button (click)="endGame()" class="board-end-btn mt-2 px-3 py-1.5 rounded-full text-xs font-medium transition pressable">{{ lang.t().end }}</button>
+    <!-- VS divider -->
+    <div class="board-vs-divider flex flex-col items-center justify-center">
+      <span class="board-vs text-xs font-black text-muted-foreground">VS</span>
+      <button (click)="endGame()" class="board-end-btn mt-2 p-1.5 rounded-full transition pressable" title="{{ lang.t().end }}">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+        </svg>
+      </button>
     </div>
 
     <!-- Player 2 Score Card -->
-    <div [class]="'board-score-card board-score-card--p2 flex-1 rounded-xl p-3 text-center transition-all ' + scoreCardClass(1)">
-      <div class="board-player-name board-player-name--p2 text-xs font-bold mb-1">{{ players()[1]?.name }}</div>
-      <div class="board-score text-2xl font-black">{{ players()[1]?.score ?? 0 }}</div>
-      <div class="flex flex-wrap justify-center gap-1 mt-1.5">
-        <span [class]="'board-pill text-xs px-1.5 py-0.5 rounded ' + (players()[1]?.lifelineUsed ? 'opacity-40 line-through' : '')">50/50</span>
-        <span [class]="'board-pill text-xs px-1.5 py-0.5 rounded ' + (players()[1]?.doubleUsed ? 'opacity-40 line-through' : '')">2x</span>
-      </div>
-      @if (store.currentStreak()[1] > 0 || store.totalAnswered()[1] > 0) {
-        <div class="flex flex-wrap justify-center gap-1 mt-1.5">
-          @if (store.currentStreak()[1] > 0) {
-            <span class="board-stat-pill text-xs px-1.5 py-0.5 rounded-full">{{ store.currentStreak()[1] }} streak</span>
-          }
-          @if (store.totalAnswered()[1] > 0) {
-            <span class="board-stat-pill text-xs px-1.5 py-0.5 rounded-full">{{ store.accuracy()[1] }}%</span>
+    <div [class]="'board-score-card board-score-card--p2 flex-1 rounded-2xl overflow-hidden transition-all ' + scoreCardClass(1)">
+      <!-- Turn indicator strip -->
+      @if (isActivePlayer(1)) {
+        <div class="board-turn-strip board-turn-strip--p2"></div>
+      }
+      <div class="p-4">
+        <!-- Header: Name + Turn badge -->
+        <div class="flex items-center justify-between mb-2">
+          <span class="board-player-name board-player-name--p2 text-sm font-bold uppercase tracking-wide">{{ players()[1]?.name }}</span>
+          @if (isActivePlayer(1)) {
+            <span class="board-turn-badge board-turn-badge--p2 text-[10px] font-bold uppercase px-2 py-0.5 rounded">{{ lang.t().turn }}</span>
           }
         </div>
-      }
-      @if (isActivePlayer(1) && !players()[1]?.doubleUsed) {
-        @if (store.doubleArmed()) {
-          <div class="mt-1.5 text-xs font-bold text-win">2x ARMED</div>
-        } @else {
-          <button (click)="armDouble()" class="board-double-btn mt-1.5 w-full py-1 rounded-lg text-xs font-bold transition pressable">{{ lang.t().use2x }}</button>
+        
+        <!-- Score -->
+        <div class="board-score text-4xl font-black mb-3">{{ players()[1]?.score ?? 0 }}</div>
+        
+        <!-- Power-ups row -->
+        <div class="flex items-center gap-2 mb-2">
+          <span [class]="'board-powerup text-xs font-semibold px-2 py-1 rounded-md ' + (players()[1]?.lifelineUsed ? 'board-powerup--used' : '')">50/50</span>
+          <span [class]="'board-powerup text-xs font-semibold px-2 py-1 rounded-md ' + (players()[1]?.doubleUsed ? 'board-powerup--used' : '')">2x</span>
+          @if (isActivePlayer(1) && !players()[1]?.doubleUsed) {
+            @if (store.doubleArmed()) {
+              <span class="board-powerup-armed text-xs font-bold px-2 py-1 rounded-md">2x ARMED</span>
+            } @else {
+              <button (click)="armDouble()" class="board-use-double text-xs font-bold px-2 py-1 rounded-md transition pressable">{{ lang.t().use2x }}</button>
+            }
+          }
+        </div>
+        
+        <!-- Stats row -->
+        @if (store.currentStreak()[1] > 0 || store.totalAnswered()[1] > 0) {
+          <div class="flex items-center gap-2">
+            @if (store.currentStreak()[1] > 0) {
+              <span class="board-stat text-xs font-medium">{{ store.currentStreak()[1] }} streak</span>
+            }
+            @if (store.totalAnswered()[1] > 0) {
+              <span class="board-stat text-xs font-medium">{{ store.accuracy()[1] }}%</span>
+            }
+          </div>
         }
-      }
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
- Redesigned the 2-player score bar to improve the layout and readability of scores, power-ups, and the active player indicator.
- Updated game mode badges, including renaming "8P" to "8 Players" and changing the Solo mode badge color to gold.
- Relocated the profile avatar upload button to sit inside the avatar circle.
- Refined UI colors, including a new lime green background for 2-player cards and updated gold CTA gradients.

[v0 Session](https://v0.app/chat/OPmqQLwuz6u)