### PR TITLE
feat: rebrand header to STEPOVR with Alfa Slab One font

### DIFF
--- a/frontend/src/app/shared/top-nav/top-nav.css
+++ b/frontend/src/app/shared/top-nav/top-nav.css
@@ -71,14 +71,13 @@
 }
 
 .top-nav__brand {
-  font-family: 'Space Grotesk', sans-serif;
-  font-size: 1.375rem;
-  font-weight: 900;
-  font-style: italic;
+  font-family: "Alfa Slab One", serif;
+  font-size: 2em;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: -0.04em;
+  letter-spacing: 0.04em;
   color: #ffffff;
-  text-decoration: none;
+  font-style: italic;
 }
 
 /* Right: Stat pill */

--- a/frontend/src/app/shared/top-nav/top-nav.html
+++ b/frontend/src/app/shared/top-nav/top-nav.html
@@ -14,7 +14,7 @@
         <img src="/icons/quizball-unlimited-logo.png" alt="Quizball" class="top-nav__logo-img" />
       </a>
     }
-    <a routerLink="/" class="top-nav__brand">QUIZBALL</a>
+    <a routerLink="/" class="top-nav__brand">STEPOVR.</a>
   </div>
 
   <!-- Right: Stat pill + Settings -->

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,6 +1,14 @@
 // Angular Material theming — kickup-inspired green palette
 @use '@angular/material' as mat;
 
+@font-face {
+  font-family: 'Alfa Slab One';
+  src: url('/Alfa_Slab_One/AlfaSlabOne-Regular.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
 html {
   color-scheme: light;
   @include mat.theme((


### PR DESCRIPTION
## Summary
- Replace brand text from `QUIZBALL` → `STEPOVR.` in the top-nav header
- Register `Alfa Slab One` custom font via `@font-face` in global styles
- Update brand typography: slab serif, bold italic, wider letter-spacing

## Test plan
- [ ] Verify "STEPOVR." renders in Alfa Slab One in the header
- [ ] Confirm font loads correctly (check Network tab for .ttf)
- [ ] Check light and dark theme appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)