### PR TITLE
fix: isolate battle royale rooms by mode in queue and matchmaker

### DIFF
--- a/backend/src/battle-royale/battle-royale.service.ts
+++ b/backend/src/battle-royale/battle-royale.service.ts
@@ -121,6 +121,7 @@ export class BattleRoyaleService {
       .select('id, host_id')
       .eq('status', 'waiting')
       .eq('is_private', false)
+      .eq('mode', 'classic')
       .limit(5);
 
     // Check if user is already in a room
@@ -177,6 +178,7 @@ export class BattleRoyaleService {
       .select('id, invite_code, host_id, created_at')
       .eq('status', 'waiting')
       .eq('is_private', false)
+      .eq('mode', 'classic')
       .order('created_at', { ascending: false })
       .limit(20);
 

--- a/backend/src/bot/bot-matchmaker.service.ts
+++ b/backend/src/bot/bot-matchmaker.service.ts
@@ -173,6 +173,7 @@ export class BotMatchmakerService {
       .from('battle_royale_rooms')
       .select('id, host_id')
       .eq('status', 'waiting')
+      .eq('mode', 'classic')
       .lt('created_at', cutoff)
       .limit(5);
 
@@ -254,7 +255,8 @@ export class BotMatchmakerService {
       .from('battle_royale_rooms')
       .select('*', { count: 'exact', head: true })
       .eq('status', 'waiting')
-      .eq('is_private', false);
+      .eq('is_private', false)
+      .eq('mode', 'classic');
 
     if (error) {
       this.logger.warn(`[Matchmaker] Could not count waiting BR rooms: ${error.message}`);


### PR DESCRIPTION
## Summary

Classic battle royale and team_logo rooms shared the same room pool. Players queuing for classic BR could land in a team_logo room, the lobby showed both types mixed, and the bot matchmaker filled/counted all rooms regardless of mode.

**Fix:** Added `.eq('mode', 'classic')` filter to 4 queries across 2 files:
- `battle-royale.service.ts`: `joinQueue()` and `getPublicRooms()`
- `bot-matchmaker.service.ts`: `injectBotsIntoBattleRoyaleRooms()` and `createBotBRRooms()`

## Pre-Landing Review
No issues found.

## Test plan
- [x] Pre-existing test failures only (37 failures in unrelated spec files — llm, mayhem, question-pool)
- [x] TypeScript compiles cleanly
- [x] Column `mode` confirmed in migration `20260428000000` with default `'classic'` and CHECK constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)