### PR TITLE
refactor: restyle News Mode to match Today in Football visual design

### DIFF
--- a/frontend/src/app/features/news-mode/news-mode.css
+++ b/frontend/src/app/features/news-mode/news-mode.css
@@ -1,230 +1,113 @@
 :host.news-mode-host {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  min-height: 100dvh;
 }
+
 .news-root {
   flex: 1;
   min-height: 100dvh;
+  position: relative;
+  overflow: hidden;
 }
 
-/* Header */
-.news-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: .75rem 0;
-  margin-bottom: 1rem;
+/* Background — same pattern as daily */
+.news-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  opacity: 1;
 }
 
-.news-title {
-  font-size: 1.75rem;
+.news-bg-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(20%) brightness(40%);
+}
+
+.news-bg-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, transparent, rgba(14, 14, 14, 0.8), rgb(14, 14, 14));
+}
+
+/* Progress bar — neon-glow fill */
+.news-progress-bar {
+  width: 100%;
+  height: 6px;
+  background: rgba(38, 38, 38, 1);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+}
+
+.news-progress-fill {
+  height: 100%;
+  background: linear-gradient(to right, #daff6f, var(--color-accent));
+  border-radius: var(--radius-full);
+  box-shadow: 0 0 15px rgba(195, 244, 0, 0.3);
+  transition: width 0.3s;
+}
+
+/* Score */
+.news-score {
   font-weight: 900;
-  line-height: 1;
-}
-
-.news-title-news {
-  color: var(--color-foreground);
-  font-style: italic;
-}
-
-.news-title-mode {
+  font-size: 1.25rem;
   color: var(--color-accent);
-  font-style: italic;
 }
 
-.news-header-right {
-  display: flex;
-  align-items: center;
-}
-
-.news-counter {
-  font-size: .875rem;
-  font-weight: 600;
-  color: var(--color-muted-foreground);
-}
-
-/* Category badge */
+/* Category badge — accent-colored like daily */
 .news-category-badge {
   display: inline-flex;
-  align-self: flex-start;
-  font-size: .6rem;
-  font-weight: 700;
+  font-size: .625rem;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: .1em;
-  color: var(--color-muted-foreground);
+  letter-spacing: .2em;
+  color: var(--color-accent);
+  background: rgba(195, 244, 0, 0.1);
   padding: .375rem .75rem;
-  border-radius: .375rem;
-  border: 1px solid rgba(255,255,255,.1);
-  margin-bottom: .75rem;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(195, 244, 0, 0.2);
 }
 
-/* Question card — Stitch: glass-card + neon-glow */
-.news-question-card {
-  background: rgba(26, 25, 25, 0.7);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(73, 72, 71, 0.15);
-  border-radius: var(--radius-lg);
-  padding: 2rem;
-  min-height: 8rem;
-  display: flex;
-  align-items: center;
-  box-shadow: 0 0 15px rgba(218, 255, 111, 0.2);
+/* Question text — bare headline, no card */
+.news-question-text {
+  font-size: 1.875rem;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  color: var(--color-foreground);
+  margin: 0 0 2rem;
 }
 
-.news-question-card--reveal {
-  align-items: flex-start;
-}
-
-/* Input — Stitch: surface-container-lowest + outline-variant border */
+/* Input — surface-container-lowest + outline-variant border */
 .news-input {
   width: 100%;
-  padding: 1rem 1.25rem;
+  padding: 1.25rem;
   border-radius: var(--radius-lg);
-  background: #000000;
-  border: 1px solid rgba(73, 72, 71, 0.2);
+  background: rgba(32, 31, 31, 1);
+  border: 1px solid rgba(73, 72, 71, 0.15);
   color: var(--color-foreground);
   font-size: 1rem;
+  font-weight: 600;
+  transition: all 0.2s;
 }
 
 .news-input:focus {
   outline: none;
   border-color: var(--color-accent);
+  background: rgba(44, 44, 44, 1);
 }
 
 .news-input::placeholder {
   color: rgba(173, 170, 170, 0.4);
+  font-weight: 400;
 }
 
-/* Submit / Check Answer — Stitch: gradient-button */
-.news-submit-btn {
-  width: 100%;
-  padding: 1.25rem;
-  margin-top: 1.25rem;
-  border-radius: var(--radius-lg);
-  background: linear-gradient(135deg, #daff6f 0%, var(--color-accent) 100%) !important;
-  color: #4c6200 !important;
-  font-weight: 700;
-  font-size: .875rem;
-  text-transform: uppercase;
-  letter-spacing: .12em;
-  border: none;
-  cursor: pointer;
-  box-shadow: 0 4px 20px rgba(195, 244, 0, 0.3);
-  transition: transform .15s;
-  -webkit-appearance: none;
-}
-
-.news-submit-btn:active:not(:disabled) {
-  transform: scale(0.95);
-}
-
-.news-submit-btn:disabled {
-  opacity: .35;
-  cursor: not-allowed;
-}
-
-/* Result badge */
-.news-result-badge {
-  font-size: .65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  padding: .375rem .75rem;
-  border-radius: var(--radius-full);
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-.news-result-badge--correct {
-  background: rgba(34, 197, 94, .15);
-  color: var(--color-success);
-}
-
-.news-result-badge--wrong {
-  background: rgba(239, 68, 68, .15);
-  color: #f87171;
-}
-
-/* Answer reveal row */
-.news-answer-reveal {
-  display: flex;
-  align-items: center;
-  gap: .75rem;
-  padding: .875rem 1rem;
-  border-radius: var(--radius-lg);
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--color-foreground);
-}
-
-.news-answer-reveal--correct {
-  background: rgba(195, 244, 0, .1);
-  border: 1px solid rgba(195, 244, 0, .25);
-}
-
-.news-answer-reveal--wrong {
-  background: rgba(147, 0, 10, .15);
-  border: 1px solid rgba(255, 180, 171, .2);
-}
-
-.news-answer-reveal--correct-revealed {
-  background: rgba(34, 197, 94, .1);
-  border: 1px solid rgba(34, 197, 94, .25);
-}
-
-.news-answer-icon {
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: .75rem;
-  font-weight: 700;
-  flex-shrink: 0;
-}
-
-.news-answer-reveal--correct .news-answer-icon {
-  background: rgba(195, 244, 0, .2);
-  color: var(--color-accent);
-}
-
-.news-answer-reveal--wrong .news-answer-icon {
-  background: rgba(255, 180, 171, .15);
-  color: var(--color-error);
-}
-
-.news-answer-reveal--correct-revealed .news-answer-icon {
-  background: rgba(34, 197, 94, .15);
-  color: var(--color-success);
-}
-
-.news-answer-tag {
-  margin-left: auto;
-  font-size: .6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .06em;
-  color: var(--color-muted-foreground);
-  flex-shrink: 0;
-}
-
-/* Score card */
-.news-score-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem;
-  margin-top: 1rem;
-  border-radius: var(--radius-lg);
-  background: rgba(255,255,255,.06);
-  border: 1px solid rgba(255,255,255,.12);
-}
-
-/* Next question — Stitch: gradient from-primary to-primary-container */
-.news-next-btn {
+/* Primary action button — gradient from-primary to-primary-container */
+.news-action-btn {
   width: 100%;
   padding: 1.25rem;
   border-radius: var(--radius-lg);
@@ -239,27 +122,134 @@
   box-shadow: 0 8px 24px rgba(195, 244, 0, 0.2);
   transition: transform .15s;
   -webkit-appearance: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
 }
 
-.news-next-btn:active {
+.news-action-btn:active:not(:disabled) {
   transform: scale(0.95);
 }
 
-/* Exit button */
-.news-exit-btn {
-  width: 100%;
-  padding: .75rem;
-  margin-top: .75rem;
-  border-radius: var(--radius-lg);
-  background: transparent;
-  border: 1px solid rgba(255,255,255,.12);
-  color: var(--color-muted-foreground);
-  font-weight: 600;
-  font-size: .875rem;
-  cursor: pointer;
-  transition: background .2s;
+.news-action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
-.news-exit-btn:hover {
-  background: rgba(255,255,255,.06);
+/* Answer reveal row */
+.news-answer-reveal {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  padding: 1.25rem;
+  border-radius: var(--radius-lg);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+}
+
+.news-answer-reveal--correct {
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+
+.news-answer-reveal--wrong {
+  background: var(--color-error-bg, rgba(147, 0, 10, 0.3));
+  border: 1px solid rgba(255, 180, 171, 0.2);
+}
+
+.news-answer-reveal--correct-revealed {
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+
+/* Answer icon */
+.news-answer-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: .75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.news-answer-icon--correct {
+  background: rgba(34, 197, 94, 0.2);
+  color: var(--color-success);
+}
+
+.news-answer-icon--wrong {
+  background: rgba(255, 180, 171, 0.15);
+  color: var(--color-error);
+}
+
+.news-answer-icon--revealed {
+  background: rgba(34, 197, 94, 0.15);
+  color: var(--color-success);
+}
+
+/* Answer tag */
+.news-answer-tag {
+  margin-left: auto;
+  font-size: .65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  opacity: .6;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* Result badge inline */
+.news-result-badge {
+  display: inline-flex;
+  font-size: .625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .2em;
+  padding: .375rem .75rem;
+  border-radius: var(--radius-full);
+}
+
+.news-result-badge--correct {
+  color: var(--color-success);
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}
+
+.news-result-badge--wrong {
+  color: var(--color-error);
+  background: rgba(147, 0, 10, 0.3);
+  border: 1px solid var(--color-error-bg, rgba(255, 180, 171, 0.2));
+}
+
+/* Explanation */
+.news-explanation {
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border-radius: var(--radius-lg);
+  background: rgba(26, 25, 25, 0.5);
+  border: 1px solid rgba(73, 72, 71, 0.15);
+}
+
+/* Secondary button */
+.news-secondary-btn {
+  width: 100%;
+  max-width: 20rem;
+  padding: .75rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(73, 72, 71, 0.15);
+  background: transparent;
+  color: var(--color-muted-foreground);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .2s, transform .15s;
+}
+
+.news-secondary-btn:active {
+  transform: scale(0.95);
 }

--- a/frontend/src/app/features/news-mode/news-mode.html
+++ b/frontend/src/app/features/news-mode/news-mode.html
@@ -1,21 +1,17 @@
-<div class="news-root bg-background flex flex-col p-4 pb-28">
-  <div class="max-w-2xl mx-auto w-full flex flex-col flex-1">
-
-    <!-- Header -->
-    <div class="news-header">
-      <div class="news-title">
-        <span class="news-title-news">NEWS</span> <span class="news-title-mode">MODE</span>
-      </div>
-      <div class="news-header-right">
-        @if (phase() !== 'loading' && total() > 0) {
-          <span class="news-counter">{{ currentIndex() + 1 }}/{{ total() }}</span>
-        }
-      </div>
-    </div>
+<div class="news-root bg-background flex flex-col">
+  <!-- Background image — same pattern as daily -->
+  <div class="news-bg">
+    <img src="/news-mode.png" alt="" class="news-bg-img" />
+    <div class="news-bg-overlay"></div>
+  </div>
+  <div class="max-w-2xl mx-auto w-full flex flex-col flex-1 px-6 pt-6 pb-28 relative z-10">
 
     <!-- LOADING -->
     @if (phase() === 'loading') {
-      <div class="flex-1 flex items-center justify-center">
+      <div class="flex-1 flex flex-col items-center justify-center">
+        <div class="text-6xl mb-6">📰</div>
+        <h2 class="text-2xl font-black text-foreground mb-2">News Mode</h2>
+        <p class="text-muted-foreground text-center mb-8">Test your knowledge on the latest football headlines.</p>
         <div class="text-5xl" style="animation: spin 1s linear infinite;">⚽</div>
       </div>
     }
@@ -24,21 +20,28 @@
     @if (phase() === 'question' && currentQuestion()) {
       <div class="flex flex-col flex-1">
         <!-- Progress bar -->
-        <div class="w-full h-1 bg-muted rounded-full mb-6 overflow-hidden">
-          <div
-            class="h-full bg-teal-500 rounded-full transition-all duration-300"
-            [style.width]="progressPercent() + '%'"
-          ></div>
+        <div class="news-progress-bar">
+          <div class="news-progress-fill" [style.width]="progressPercent() + '%'"></div>
         </div>
 
-        <!-- Question card -->
-        <div class="news-question-card">
-          <p class="text-foreground text-xl font-bold leading-relaxed">{{ currentQuestion()!.question_text }}</p>
+        <!-- Header: question counter + score -->
+        <div class="flex items-center justify-between mb-6">
+          <span class="text-muted-foreground text-sm">
+            Question {{ currentIndex() + 1 }} of {{ total() }}
+          </span>
+          <span class="news-score">{{ correctCount() }}/{{ total() }}</span>
         </div>
+
+        <!-- Category badge -->
+        <div class="mb-4">
+          <span class="news-category-badge">LATEST NEWS</span>
+        </div>
+
+        <!-- Question text (bare headline — no card) -->
+        <h2 class="news-question-text">{{ currentQuestion()!.question_text }}</h2>
 
         <!-- Answer input -->
-        <div class="mt-4">
-          <div class="text-muted-foreground text-xs font-semibold uppercase tracking-wider mb-2">Your Answer</div>
+        <div class="mb-4">
           <input
             [(ngModel)]="answer"
             (keydown.enter)="submitAnswer()"
@@ -51,7 +54,7 @@
         <button
           (click)="submitAnswer()"
           [disabled]="!answer.trim() || submitting()"
-          class="news-submit-btn"
+          class="news-action-btn"
         >
           CHECK ANSWER
         </button>
@@ -62,35 +65,41 @@
     @if (phase() === 'result' && lastResult()) {
       <div class="flex flex-col flex-1">
         <!-- Progress bar -->
-        <div class="w-full h-1 bg-muted rounded-full mb-6 overflow-hidden">
-          <div
-            class="h-full bg-teal-500 rounded-full transition-all duration-300"
-            [style.width]="progressPercent() + '%'"
-          ></div>
-        </div>
-        <!-- Question card with result badge -->
-        <div class="news-question-card news-question-card--reveal">
-          <div class="flex items-start justify-between gap-3">
-            <p class="text-foreground text-xl font-bold leading-relaxed flex-1">{{ currentQuestion()!.question_text }}</p>
-          </div>
+        <div class="news-progress-bar">
+          <div class="news-progress-fill" [style.width]="progressPercent() + '%'"></div>
         </div>
 
+        <!-- Header: question counter + result badge -->
+        <div class="flex items-center justify-between mb-6">
+          <span class="text-muted-foreground text-sm">
+            Question {{ currentIndex() + 1 }} of {{ total() }}
+          </span>
+          <span class="news-result-badge" [class]="lastResult()!.correct ? 'news-result-badge news-result-badge--correct' : 'news-result-badge news-result-badge--wrong'">
+            {{ lastResult()!.correct ? 'CORRECT' : 'WRONG' }}
+          </span>
+        </div>
+
+        <!-- Category badge -->
+        <div class="mb-4">
+          <span class="news-category-badge">LATEST NEWS</span>
+        </div>
+
+        <!-- Question text (bare headline) -->
+        <h2 class="news-question-text">{{ currentQuestion()!.question_text }}</h2>
+
         <!-- Your answer -->
-        <div class="mt-4">
-          <div class="text-muted-foreground text-xs font-semibold uppercase tracking-wider mb-2">Your Answer</div>
-          <div class="news-answer-reveal" [class]="lastResult()!.correct ? 'news-answer-reveal--correct' : 'news-answer-reveal--wrong'">
-            <span class="news-answer-icon">{{ lastResult()!.correct ? '✓' : '✗' }}</span>
-            <span>{{ userAnswer() }}</span>
-            <span class="news-answer-tag">{{ lastResult()!.correct ? 'CORRECT' : 'YOUR CHOICE' }}</span>
-          </div>
+        <div class="news-answer-reveal" [class]="lastResult()!.correct ? 'news-answer-reveal news-answer-reveal--correct' : 'news-answer-reveal news-answer-reveal--wrong'">
+          <span class="news-answer-icon" [class]="lastResult()!.correct ? 'news-answer-icon news-answer-icon--correct' : 'news-answer-icon news-answer-icon--wrong'">{{ lastResult()!.correct ? '✓' : '✗' }}</span>
+          <span class="font-bold text-lg">{{ userAnswer() }}</span>
+          <span class="news-answer-tag">{{ lastResult()!.correct ? 'CORRECT' : 'YOUR ANSWER' }}</span>
         </div>
 
         <!-- Correct answer (if wrong) -->
         @if (!lastResult()!.correct) {
           <div class="mt-3">
             <div class="news-answer-reveal news-answer-reveal--correct-revealed">
-              <span class="news-answer-icon">✓</span>
-              <span>{{ lastResult()!.correct_answer }}</span>
+              <span class="news-answer-icon news-answer-icon--revealed">✓</span>
+              <span class="font-bold text-lg">{{ lastResult()!.correct_answer }}</span>
               <span class="news-answer-tag">CORRECT ANSWER</span>
             </div>
           </div>
@@ -98,37 +107,30 @@
 
         <!-- Explanation -->
         @if (lastResult()!.explanation) {
-          <div class="text-muted-foreground text-sm mt-4 leading-relaxed">{{ lastResult()!.explanation }}</div>
+          <div class="news-explanation mt-4">
+            <p class="text-muted-foreground text-sm leading-relaxed">{{ lastResult()!.explanation }}</p>
+          </div>
         }
 
         <!-- Source -->
         @if (currentQuestion()!.source_url) {
           <a [href]="currentQuestion()!.source_url" target="_blank" rel="noopener"
-             class="inline-block text-teal-400 text-xs mt-2 underline">
+             class="inline-block text-accent text-xs mt-2 underline opacity-60">
             Source →
           </a>
         }
 
-        <!-- Score -->
-        <div class="news-score-card">
-          <span class="text-muted-foreground text-sm">Score</span>
-          <span class="font-black text-2xl text-teal-400">{{ correctCount() }} / {{ currentIndex() + 1 }}</span>
-        </div>
-
         <!-- Actions -->
         <div class="mt-auto pt-4">
           @if (hasMore()) {
-            <button (click)="nextQuestion()" class="news-next-btn">
+            <button (click)="nextQuestion()" class="news-action-btn">
               NEXT QUESTION →
             </button>
           } @else {
-            <button (click)="finish()" class="news-next-btn">
+            <button (click)="finish()" class="news-action-btn">
               SEE RESULTS →
             </button>
           }
-          <button (click)="goHome()" class="news-exit-btn">
-            Exit
-          </button>
         </div>
       </div>
     }
@@ -136,26 +138,15 @@
     <!-- FINISHED -->
     @if (phase() === 'finished') {
       <div class="flex-1 flex flex-col items-center justify-center">
-        <div class="text-5xl mb-4">📰</div>
+        <div class="text-5xl mb-4">🏆</div>
         <h2 class="text-2xl font-black text-foreground mb-2">Session Complete!</h2>
-        <p class="text-muted-foreground text-center mb-8">You answered all available news questions.</p>
-        <div class="w-full max-w-xs space-y-3 mb-8">
-          <div class="flex justify-between p-4 bg-card rounded-xl border border-border">
-            <span class="text-muted-foreground">Questions</span>
-            <span class="text-foreground font-bold">{{ total() }}</span>
-          </div>
-          <div class="flex justify-between p-4 bg-card rounded-xl border border-border">
-            <span class="text-muted-foreground">Correct</span>
-            <span class="text-win font-bold">{{ correctCount() }}</span>
-          </div>
-          <div class="flex justify-between p-4 bg-card rounded-xl border border-border">
-            <span class="text-muted-foreground">Accuracy</span>
-            <span class="text-teal-400 font-bold">{{ accuracy() }}%</span>
-          </div>
-        </div>
+        <div class="text-6xl font-black text-accent mb-2 tabular-nums">{{ correctCount() }}/{{ total() }}</div>
+        <p class="text-muted-foreground mb-8">{{ accuracy() }}% correct</p>
+
         <button
           (click)="goHome()"
-          class="w-full max-w-xs py-4 rounded-2xl bg-teal-600 text-white font-black text-xl hover:bg-teal-500 active:scale-95 transition pressable"
+          class="news-action-btn mb-3"
+          style="max-width: 20rem;"
         >
           Back to Home
         </button>
@@ -165,10 +156,13 @@
     <!-- Empty state -->
     @if (phase() === 'question' && total() === 0) {
       <div class="flex-1 flex flex-col items-center justify-center text-center">
-        <div class="text-5xl mb-4">📭</div>
-        <h2 class="text-xl font-black text-foreground mb-2">No questions available</h2>
-        <p class="text-muted-foreground mb-8">Check back later — news questions refresh every 6 hours.</p>
-        <button (click)="goHome()" class="py-3 px-8 rounded-xl bg-teal-600 text-white font-bold">Back to Home</button>
+        <div class="text-6xl mb-6">📰</div>
+        <h2 class="text-2xl font-black text-foreground mb-2">No questions available</h2>
+        <p class="text-muted-foreground text-center mb-2">Check back later — news questions refresh every 6 hours.</p>
+        <p class="text-muted-foreground text-sm text-center mb-8 max-w-xs">New headlines are added throughout the day.</p>
+        <button (click)="goHome()" class="news-action-btn" style="max-width: 20rem;">
+          Back to Home
+        </button>
       </div>
     }
   </div>


### PR DESCRIPTION
## Summary
Visual refactor of the News Mode component to match the Today in Football (Daily) component's look and feel. Functionality unchanged — free-text input preserved.

- **Background**: Added fixed full-page background image with grayscale filter + gradient overlay
- **Question display**: Replaced glass card with bare headline text (1.875rem, tight letter-spacing)
- **Progress bar**: Replaced thin teal Tailwind bar with 6px neon-glow bar (lime gradient + box-shadow)
- **Buttons**: Unified to single `news-action-btn` class matching Daily's gradient style
- **Badges**: Accent-colored category badge (`LATEST NEWS`) and result badges matching Daily's pill style
- **Finished screen**: Replaced stat cards with big score display (6xl font, accent color, trophy emoji)
- **Colors**: Replaced all `text-teal-*` accents with `var(--color-accent)` lime theme
- **Removed**: Glass card, "NEWS MODE" italic header, teal-600 buttons, score card, exit button (native app back nav)

## Pre-Landing Review
No issues found.

## Design Review
Design Review (lite): 0 findings. Visual alignment to existing Daily component pattern.

## Adversarial Review
Claude adversarial subagent found no actionable issues. Noted pre-existing patterns ([class] binding style, missing exit button matches Daily's pattern for native app).

## Test plan
- [x] Angular production build passes (0 errors)
- [x] Pre-existing warnings only (bundle size, game-question.css, scriptjs ESM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)