### PR TITLE
refactor: remove Mayhem and Logo Quiz from leaderboard

### DIFF
--- a/backend/src/leaderboard/leaderboard.controller.ts
+++ b/backend/src/leaderboard/leaderboard.controller.ts
@@ -10,23 +10,21 @@ export class LeaderboardController {
 
   @Get()
   async getLeaderboard() {
-    const [solo, blitz, logoQuiz] = await Promise.all([
+    const [solo, blitz] = await Promise.all([
       this.supabaseService.getLeaderboard(LIMIT),
       this.supabaseService.getBlitzLeaderboard(LIMIT),
-      this.supabaseService.getLogoQuizLeaderboard(LIMIT),
     ]);
-    return { solo, blitz, logoQuiz };
+    return { solo, blitz };
   }
 
   @Get('me')
   @UseGuards(AuthGuard)
   async getMyLeaderboardEntries(@Req() req: any) {
     const userId = req.user.id;
-    const [soloMe, blitzMe, logoQuizMe] = await Promise.all([
+    const [soloMe, blitzMe] = await Promise.all([
       this.supabaseService.getLeaderboardEntryForUser(userId),
       this.supabaseService.getBlitzLeaderboardEntryForUser(userId),
-      this.supabaseService.getLogoQuizLeaderboardEntryForUser(userId),
     ]);
-    return { soloMe, blitzMe, logoQuizMe };
+    return { soloMe, blitzMe };
   }
 }

--- a/frontend/src/app/core/leaderboard-api.service.ts
+++ b/frontend/src/app/core/leaderboard-api.service.ts
@@ -8,23 +8,14 @@ import type { BlitzLeaderboardEntry } from './blitz-api.service';
 
 export type { LeaderboardEntry, BlitzLeaderboardEntry };
 
-export interface LogoQuizLeaderboardEntry {
-  id: string;
-  username: string;
-  logo_quiz_elo: number;
-  logo_quiz_games_played: number;
-}
-
 export interface LeaderboardResponse {
   solo: LeaderboardEntry[];
   blitz: BlitzLeaderboardEntry[];
-  logoQuiz: LogoQuizLeaderboardEntry[];
 }
 
 export interface MyLeaderboardEntriesResponse {
   soloMe: (LeaderboardEntry & { rank: number }) | null;
   blitzMe: (BlitzLeaderboardEntry & { rank: number }) | null;
-  logoQuizMe: (LogoQuizLeaderboardEntry & { rank: number }) | null;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/frontend/src/app/features/leaderboard/leaderboard.html
+++ b/frontend/src/app/features/leaderboard/leaderboard.html
@@ -19,7 +19,7 @@
 
   @if (!loading() || entries().length > 0) {
     <!-- Your Ranks Summary Card (only for logged in users) -->
-    @if (auth.isLoggedIn() && (soloMeEntry() || blitzMeEntry() || mayhemMeEntry() || logoQuizMeEntry())) {
+    @if (auth.isLoggedIn() && (soloMeEntry() || blitzMeEntry())) {
       <section class="your-ranks-section">
         <div class="your-ranks-header">
           <span class="your-ranks-label">Your Rankings</span>
@@ -55,36 +55,6 @@
               </div>
             </a>
           }
-          @if (mayhemMeEntry(); as me) {
-            <a [routerLink]="['/profile', me.user_id]" class="your-rank-card your-rank-card--mayhem">
-              <div class="your-rank-icon">
-                <mat-icon>whatshot</mat-icon>
-              </div>
-              <div class="your-rank-info">
-                <span class="your-rank-mode">Mayhem</span>
-                <span class="your-rank-value">#{{ me.rank }}</span>
-              </div>
-              <div class="your-rank-score">
-                <span class="your-rank-score-value">{{ me.current_elo }}</span>
-                <span class="your-rank-score-label">ELO</span>
-              </div>
-            </a>
-          }
-          @if (logoQuizMeEntry(); as me) {
-            <a [routerLink]="['/profile', me.id]" class="your-rank-card your-rank-card--logo-quiz">
-              <div class="your-rank-icon">
-                <mat-icon>image_search</mat-icon>
-              </div>
-              <div class="your-rank-info">
-                <span class="your-rank-mode">Logo Quiz</span>
-                <span class="your-rank-value">#{{ me.rank }}</span>
-              </div>
-              <div class="your-rank-score">
-                <span class="your-rank-score-value">{{ me.logo_quiz_elo }}</span>
-                <span class="your-rank-score-label">ELO</span>
-              </div>
-            </a>
-          }
         </div>
       </section>
     }
@@ -104,20 +74,6 @@
         (click)="setActiveTab('blitz')">
         <mat-icon>bolt</mat-icon>
         <span>Blitz</span>
-      </button>
-      <button
-        class="mode-tab"
-        [class.mode-tab--active]="activeTab() === 'mayhem'"
-        (click)="setActiveTab('mayhem')">
-        <mat-icon>whatshot</mat-icon>
-        <span>Mayhem</span>
-      </button>
-      <button
-        class="mode-tab"
-        [class.mode-tab--active]="activeTab() === 'logo-quiz'"
-        (click)="setActiveTab('logo-quiz')">
-        <mat-icon>image_search</mat-icon>
-        <span>Logo Quiz</span>
       </button>
     </div>
 
@@ -283,166 +239,5 @@
       </section>
     }
 
-    <!-- Mayhem Tab Content -->
-    @if (activeTab() === 'mayhem') {
-      <section class="leaderboard-section">
-        @if (mayhemEntries().length > 0) {
-          <div class="leaderboard-list">
-            @for (entry of mayhemEntries(); track entry.user_id; let i = $index) {
-              <a [routerLink]="['/profile', entry.user_id]" class="leaderboard-card-link">
-                <div class="leaderboard-card" [class.leaderboard-card--you]="isCurrentUser(entry.user_id)" [class.leaderboard-card--top3]="i < 3">
-                  <div class="leaderboard-rank" [attr.data-rank]="i + 1">
-                    @if (i === 0) {
-                      <div class="rank-medal rank-medal--gold">1</div>
-                    } @else if (i === 1) {
-                      <div class="rank-medal rank-medal--silver">2</div>
-                    } @else if (i === 2) {
-                      <div class="rank-medal rank-medal--bronze">3</div>
-                    } @else {
-                      <span class="rank-number">{{ i + 1 }}</span>
-                    }
-                  </div>
-                  <div class="leaderboard-avatar">
-                    {{ entry.username.charAt(0).toUpperCase() }}
-                  </div>
-                  <div class="leaderboard-info">
-                    <div class="leaderboard-name">
-                      {{ entry.username }}
-                      @if (isCurrentUser(entry.user_id)) { 
-                        <span class="leaderboard-you-badge">YOU</span> 
-                      }
-                    </div>
-                    <div class="leaderboard-meta">
-                      {{ entry.games_played }} games
-                    </div>
-                  </div>
-                  <div class="leaderboard-score">
-                    <span class="leaderboard-score-value">{{ entry.current_elo }}</span>
-                    <span class="leaderboard-score-label">ELO</span>
-                  </div>
-                </div>
-              </a>
-            }
-          </div>
-
-          @if (showMayhemMeBelow()) {
-            <div class="leaderboard-separator">
-              <span class="leaderboard-separator-line"></span>
-              <span class="leaderboard-separator-text">{{ lang.t().lbYourRank }}</span>
-              <span class="leaderboard-separator-line"></span>
-            </div>
-            <a [routerLink]="['/profile', mayhemMeEntry()!.user_id]" class="leaderboard-card-link">
-              <div class="leaderboard-card leaderboard-card--you leaderboard-card--highlighted">
-                <div class="leaderboard-rank">
-                  <span class="rank-number rank-number--you">#{{ mayhemMeEntry()!.rank }}</span>
-                </div>
-                <div class="leaderboard-avatar leaderboard-avatar--you">
-                  {{ mayhemMeEntry()!.username.charAt(0).toUpperCase() }}
-                </div>
-                <div class="leaderboard-info">
-                  <div class="leaderboard-name">
-                    {{ mayhemMeEntry()!.username }}
-                    <span class="leaderboard-you-badge">YOU</span>
-                  </div>
-                  <div class="leaderboard-meta">
-                    {{ mayhemMeEntry()!.games_played }} games
-                  </div>
-                </div>
-                <div class="leaderboard-score">
-                  <span class="leaderboard-score-value">{{ mayhemMeEntry()!.current_elo }}</span>
-                  <span class="leaderboard-score-label">ELO</span>
-                </div>
-              </div>
-            </a>
-          }
-        } @else {
-          <div class="leaderboard-empty">
-            <mat-icon>whatshot</mat-icon>
-            <p>No Mayhem players yet</p>
-          </div>
-        }
-      </section>
-    }
-
-    <!-- Logo Quiz Tab Content -->
-    @if (activeTab() === 'logo-quiz') {
-      <section class="leaderboard-section">
-        @if (logoQuizEntries().length > 0) {
-          <div class="leaderboard-list">
-            @for (entry of logoQuizEntries(); track entry.id; let i = $index) {
-              <a [routerLink]="['/profile', entry.id]" class="leaderboard-card-link">
-                <div class="leaderboard-card" [class.leaderboard-card--you]="isCurrentUser(entry.id)" [class.leaderboard-card--top3]="i < 3">
-                  <div class="leaderboard-rank" [attr.data-rank]="i + 1">
-                    @if (i === 0) {
-                      <div class="rank-medal rank-medal--gold">1</div>
-                    } @else if (i === 1) {
-                      <div class="rank-medal rank-medal--silver">2</div>
-                    } @else if (i === 2) {
-                      <div class="rank-medal rank-medal--bronze">3</div>
-                    } @else {
-                      <span class="rank-number">{{ i + 1 }}</span>
-                    }
-                  </div>
-                  <div class="leaderboard-avatar">
-                    {{ entry.username.charAt(0).toUpperCase() }}
-                  </div>
-                  <div class="leaderboard-info">
-                    <div class="leaderboard-name">
-                      {{ entry.username }}
-                      @if (isCurrentUser(entry.id)) {
-                        <span class="leaderboard-you-badge">YOU</span>
-                      }
-                    </div>
-                    <div class="leaderboard-meta">
-                      {{ entry.logo_quiz_games_played }} games played
-                    </div>
-                  </div>
-                  <div class="leaderboard-score">
-                    <span class="leaderboard-score-value">{{ entry.logo_quiz_elo }}</span>
-                    <span class="leaderboard-score-label">ELO</span>
-                  </div>
-                </div>
-              </a>
-            }
-          </div>
-
-          @if (showLogoQuizMeBelow()) {
-            <div class="leaderboard-separator">
-              <span class="leaderboard-separator-line"></span>
-              <span class="leaderboard-separator-text">{{ lang.t().lbYourRank }}</span>
-              <span class="leaderboard-separator-line"></span>
-            </div>
-            <a [routerLink]="['/profile', logoQuizMeEntry()!.id]" class="leaderboard-card-link">
-              <div class="leaderboard-card leaderboard-card--you leaderboard-card--highlighted">
-                <div class="leaderboard-rank">
-                  <span class="rank-number rank-number--you">#{{ logoQuizMeEntry()!.rank }}</span>
-                </div>
-                <div class="leaderboard-avatar leaderboard-avatar--you">
-                  {{ logoQuizMeEntry()!.username.charAt(0).toUpperCase() }}
-                </div>
-                <div class="leaderboard-info">
-                  <div class="leaderboard-name">
-                    {{ logoQuizMeEntry()!.username }}
-                    <span class="leaderboard-you-badge">YOU</span>
-                  </div>
-                  <div class="leaderboard-meta">
-                    {{ logoQuizMeEntry()!.logo_quiz_games_played }} games played
-                  </div>
-                </div>
-                <div class="leaderboard-score">
-                  <span class="leaderboard-score-value">{{ logoQuizMeEntry()!.logo_quiz_elo }}</span>
-                  <span class="leaderboard-score-label">ELO</span>
-                </div>
-              </div>
-            </a>
-          }
-        } @else {
-          <div class="leaderboard-empty">
-            <mat-icon>image_search</mat-icon>
-            <p>No Logo Quiz players yet</p>
-          </div>
-        }
-      </section>
-    }
   }
 </div>

--- a/frontend/src/app/features/leaderboard/leaderboard.ts
+++ b/frontend/src/app/features/leaderboard/leaderboard.ts
@@ -7,9 +7,7 @@ import {
   LeaderboardApiService,
   LeaderboardEntry,
   BlitzLeaderboardEntry,
-  LogoQuizLeaderboardEntry,
 } from '../../core/leaderboard-api.service';
-import { MayhemApiService, MayhemLeaderboardEntry, MayhemMeEntry } from '../../core/mayhem-api.service';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -30,27 +28,22 @@ import { MatIconModule } from '@angular/material/icon';
 })
 export class LeaderboardComponent implements OnInit {
   private leaderboardApi = inject(LeaderboardApiService);
-  private mayhemApi = inject(MayhemApiService);
   auth = inject(AuthService);
   lang = inject(LanguageService);
 
   entries = signal<LeaderboardEntry[]>([]);
   blitzEntries = signal<BlitzLeaderboardEntry[]>([]);
-  mayhemEntries = signal<MayhemLeaderboardEntry[]>([]);
-  logoQuizEntries = signal<LogoQuizLeaderboardEntry[]>([]);
   soloMeEntry = signal<(LeaderboardEntry & { rank: number }) | null>(null);
   blitzMeEntry = signal<(BlitzLeaderboardEntry & { rank: number }) | null>(null);
-  mayhemMeEntry = signal<MayhemMeEntry | null>(null);
-  logoQuizMeEntry = signal<(LogoQuizLeaderboardEntry & { rank: number }) | null>(null);
   loading = signal(false);
   error = signal<string | null>(null);
-  activeTab = signal<'solo' | 'blitz' | 'mayhem' | 'logo-quiz'>('solo');
+  activeTab = signal<'solo' | 'blitz'>('solo');
 
   ngOnInit(): void {
     this.load();
   }
 
-  setActiveTab(tab: 'solo' | 'blitz' | 'mayhem' | 'logo-quiz'): void {
+  setActiveTab(tab: 'solo' | 'blitz'): void {
     this.activeTab.set(tab);
   }
 
@@ -60,28 +53,19 @@ export class LeaderboardComponent implements OnInit {
     try {
       await this.auth.sessionReady;
       const isLoggedIn = this.auth.isLoggedIn();
-      const [leaderboardRes, meRes, mayhemRes, mayhemMeRes] = await Promise.all([
+      const [leaderboardRes, meRes] = await Promise.all([
         firstValueFrom(this.leaderboardApi.getLeaderboard()),
         isLoggedIn
           ? firstValueFrom(this.leaderboardApi.getMyLeaderboardEntries()).catch(() => ({
               soloMe: null,
               blitzMe: null,
-              logoQuizMe: null,
             }))
-          : Promise.resolve({ soloMe: null, blitzMe: null, logoQuizMe: null }),
-        firstValueFrom(this.mayhemApi.getLeaderboard()).catch(() => [] as MayhemLeaderboardEntry[]),
-        isLoggedIn
-          ? firstValueFrom(this.mayhemApi.getMyLeaderboardEntry()).catch(() => null)
-          : Promise.resolve(null),
+          : Promise.resolve({ soloMe: null, blitzMe: null }),
       ]);
       this.entries.set(leaderboardRes.solo);
       this.blitzEntries.set(leaderboardRes.blitz);
-      this.logoQuizEntries.set(leaderboardRes.logoQuiz ?? []);
       this.soloMeEntry.set(meRes.soloMe ?? null);
       this.blitzMeEntry.set(meRes.blitzMe ?? null);
-      this.logoQuizMeEntry.set(meRes.logoQuizMe ?? null);
-      this.mayhemEntries.set(mayhemRes);
-      this.mayhemMeEntry.set(mayhemMeRes);
     } catch (err: any) {
       this.error.set(this.lang.t().lbLoadFailed);
     } finally {
@@ -103,18 +87,6 @@ export class LeaderboardComponent implements OnInit {
     const me = this.blitzMeEntry();
     if (!me) return false;
     return !this.blitzEntries().some((entry) => entry.user_id === me.user_id);
-  }
-
-  showMayhemMeBelow(): boolean {
-    const me = this.mayhemMeEntry();
-    if (!me) return false;
-    return !this.mayhemEntries().some((e) => e.user_id === me.user_id);
-  }
-
-  showLogoQuizMeBelow(): boolean {
-    const me = this.logoQuizMeEntry();
-    if (!me) return false;
-    return !this.logoQuizEntries().some((e) => e.id === me.id);
   }
 
   accuracy(entry: LeaderboardEntry): number {


### PR DESCRIPTION
## Summary
- Removed Mayhem and Logo Quiz tabs from the leaderboard page
- Backend `/api/leaderboard` and `/api/leaderboard/me` no longer return logoQuiz data
- Frontend no longer imports MayhemApiService or loads Mayhem/Logo Quiz leaderboard data
- Leaderboard now shows only **Solo** (ELO) and **Blitz** (score-based) tabs
- Backend services (getLogoQuizLeaderboard, getMayhemLeaderboard, etc.) kept intact for future re-enablement

## Pre-Landing Review
No issues found.

## Adversarial Review
Claude adversarial subagent: clean. All findings were pre-existing, intentional (dead backend code kept for re-enablement), or cosmetic (dead CSS rules).

## Test plan
- [x] Frontend production build passes (verified)
- [ ] Manual: visit /leaderboard, confirm only Solo and Blitz tabs appear
- [ ] Manual: verify "Your Rankings" card shows only Solo and Blitz entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)