### PR TITLE
fix(online-lobby): 13 product-design bugs & flow caveats

### DIFF
--- a/backend/src/online-game/online-game.service.ts
+++ b/backend/src/online-game/online-game.service.ts
@@ -1022,14 +1022,25 @@ export class OnlineGameService {
     });
   }
 
-  async getGameCount(userId: string): Promise<{ count: number }> {
-    const { count } = await this.supabaseService.client
-      .from('online_games')
-      .select('id', { count: 'exact', head: true })
-      .or(`host_id.eq.${userId},guest_id.eq.${userId}`)
-      .in('status', ['waiting', 'active']);
+  /** Free-tier cap on concurrent active online games. Pro users are uncapped. */
+  static readonly FREE_TIER_MAX_ACTIVE_GAMES = 2;
 
-    return { count: count ?? 0 };
+  async getGameCount(userId: string): Promise<{ count: number; isPro: boolean; max: number }> {
+    const [{ count }, proStatus] = await Promise.all([
+      this.supabaseService.client
+        .from('online_games')
+        .select('id', { count: 'exact', head: true })
+        .or(`host_id.eq.${userId},guest_id.eq.${userId}`)
+        .in('status', ['waiting', 'active']),
+      this.supabaseService.getProStatus(userId),
+    ]);
+
+    const isPro = !!proStatus?.is_pro;
+    return {
+      count: count ?? 0,
+      isPro,
+      max: isPro ? -1 : OnlineGameService.FREE_TIER_MAX_ACTIVE_GAMES,
+    };
   }
 
   async joinQueue(userId: string): Promise<OnlinePublicView> {

--- a/frontend/src/app/core/online-game-api.service.ts
+++ b/frontend/src/app/core/online-game-api.service.ts
@@ -114,8 +114,8 @@ export class OnlineGameApiService {
     return this.http.get<OnlineGameSummary[]>(this.base, { headers: this.headers() });
   }
 
-  getGameCount(): Observable<{ count: number; isPro: boolean }> {
-    return this.http.get<{ count: number; isPro: boolean }>(`${this.base}/count`, { headers: this.headers() });
+  getGameCount(): Observable<{ count: number; isPro: boolean; max: number }> {
+    return this.http.get<{ count: number; isPro: boolean; max: number }>(`${this.base}/count`, { headers: this.headers() });
   }
 
   joinQueue(): Observable<OnlineGamePublicView> {

--- a/frontend/src/app/features/online-game/online-lobby.css
+++ b/frontend/src/app/features/online-game/online-lobby.css
@@ -159,6 +159,66 @@
   color: var(--color-fg-variant);
 }
 
+.online-active-game__badge--expired {
+  background: color-mix(in srgb, var(--color-error-text, #f87171) 18%, transparent);
+  color: var(--color-error-text, #f87171);
+}
+
+/* ── Skeleton + load-error states ── */
+.online-active-games--skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.online-active-game--skeleton {
+  display: block;
+  height: 64px;
+  border-radius: var(--radius-lg, 12px);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-white) 4%, transparent) 0%,
+    color-mix(in srgb, var(--color-white) 10%, transparent) 50%,
+    color-mix(in srgb, var(--color-white) 4%, transparent) 100%
+  );
+  background-size: 200% 100%;
+  animation: online-skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes online-skeleton-pulse {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.online-load-error {
+  width: 100%;
+  padding: var(--space-4);
+  border-radius: var(--radius-lg, 12px);
+  background: color-mix(in srgb, var(--color-error-text, #f87171) 10%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  align-items: flex-start;
+}
+
+.online-load-error__msg {
+  margin: 0;
+  color: var(--color-fg-variant);
+  font-size: 0.875rem;
+}
+
+.online-load-error__retry {
+  align-self: flex-end;
+  padding: var(--space-2) var(--space-4);
+  font-weight: 700;
+  font-size: 0.8125rem;
+  border-radius: var(--radius-full);
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+  border: none;
+  cursor: pointer;
+}
+
 /* ── Premium limit banner ── */
 .online-limit-banner {
   width: 100%;
@@ -388,6 +448,29 @@
   color: var(--color-accent-light);
 }
 
+/* ── Inline spinner (used in sheet buttons while an action is in flight) ── */
+.online-sheet__spinner {
+  display: inline-block;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
+  border-top-color: var(--color-accent);
+  animation: online-sheet-spin 0.8s linear infinite;
+}
+
+.online-sheet__spinner--on-accent {
+  border-color: color-mix(in srgb, var(--color-on-accent, #000) 25%, transparent);
+  border-top-color: var(--color-on-accent, #000);
+  width: 1rem;
+  height: 1rem;
+  border-width: 2px;
+}
+
+@keyframes online-sheet-spin {
+  to { transform: rotate(360deg); }
+}
+
 /* ── Reduced motion ── */
 @media (prefers-reduced-motion: reduce) {
   .online-sheet {
@@ -397,5 +480,13 @@
   .online-sheet__option:not(:disabled):active,
   .online-sheet__code-btn:active {
     transform: none;
+  }
+
+  .online-active-game--skeleton {
+    animation: none;
+  }
+
+  .online-sheet__spinner {
+    animation-duration: 2s;
   }
 }

--- a/frontend/src/app/features/online-game/online-lobby.html
+++ b/frontend/src/app/features/online-game/online-lobby.html
@@ -25,7 +25,17 @@
     </div>
 
     <!-- Active Games -->
-    @if (activeGames().length > 0) {
+    @if (!hasLoaded()) {
+      <div class="online-active-games online-active-games--skeleton" aria-busy="true" aria-label="Loading your games">
+        <span class="online-active-game online-active-game--skeleton"></span>
+        <span class="online-active-game online-active-game--skeleton"></span>
+      </div>
+    } @else if (loadError()) {
+      <div class="online-load-error" role="alert">
+        <p class="online-load-error__msg">{{ loadError() }}</p>
+        <button type="button" class="online-load-error__retry" (click)="retryLoad()">Retry</button>
+      </div>
+    } @else if (activeGames().length > 0) {
       <div class="online-active-games">
         <span class="online-active-games__title">
           ACTIVE GAMES ({{ activeGames().length }})
@@ -39,13 +49,13 @@
               <span class="online-active-game__score">
                 Score: {{ game.myRole === 'host' ? game.playerScores.host : game.playerScores.guest }}
                 – {{ game.myRole === 'host' ? game.playerScores.guest : game.playerScores.host }}
-                @if (game.turnDeadline && game.isMyTurn) {
+                @if (game.turnDeadline && game.isMyTurn && !isExpired(game)) {
                   <span class="online-active-game__deadline"> · {{ formatDeadline(game.turnDeadline) }}</span>
                 }
               </span>
             </div>
             <span [class]="'online-active-game__badge ' + turnBadgeClass(game)">
-              {{ game.isMyTurn ? 'Your Turn' : game.status === 'waiting' ? 'Waiting' : game.status === 'queued' ? 'Queued' : 'Their Turn' }}
+              {{ turnBadgeLabel(game) }}
             </span>
           </button>
         }
@@ -61,7 +71,7 @@
     <!-- Premium limit banner -->
     @if (atLimit()) {
       <div class="online-limit-banner">
-        <p class="online-limit-banner__title">2 active games limit reached</p>
+        <p class="online-limit-banner__title">{{ maxGames() }} active games limit reached</p>
         <p class="online-limit-banner__desc">Finish or abandon an active game, or upgrade for unlimited games.</p>
       </div>
     }
@@ -71,7 +81,7 @@
       #playButton
       class="lobby-start-btn"
       (click)="openPlaySheet()"
-      [disabled]="loading() || atLimit()"
+      [disabled]="loading() || atLimit() || !hasLoaded()"
     >
       PLAY
     </button>
@@ -85,18 +95,22 @@
     class="online-sheet"
     role="dialog"
     aria-modal="true"
-    aria-label="Start an online game"
+    aria-labelledby="online-sheet-title"
     cdkTrapFocus
     cdkTrapFocusAutoCapture
   >
     <div class="online-sheet__handle"></div>
-    <h2 class="online-sheet__title">How do you want to play?</h2>
+    <h2 class="online-sheet__title" id="online-sheet-title">How do you want to play?</h2>
 
     <div class="online-sheet__options">
       <!-- Create Game -->
       <button class="online-sheet__option" (click)="createGame()" [disabled]="loading()">
         <div class="online-sheet__option-icon-box">
-          <span class="material-symbols-outlined">swords</span>
+          @if (pendingAction() === 'create') {
+            <span class="online-sheet__spinner" aria-hidden="true"></span>
+          } @else {
+            <span class="material-symbols-outlined">swords</span>
+          }
         </div>
         <div class="online-sheet__option-text">
           <span class="online-sheet__option-title">Create Game</span>
@@ -107,22 +121,30 @@
       <!-- Random Opponent -->
       <button class="online-sheet__option" (click)="joinQueue()" [disabled]="loading()">
         <div class="online-sheet__option-icon-box">
-          <span class="material-symbols-outlined">casino</span>
+          @if (pendingAction() === 'queue') {
+            <span class="online-sheet__spinner" aria-hidden="true"></span>
+          } @else {
+            <span class="material-symbols-outlined">casino</span>
+          }
         </div>
         <div class="online-sheet__option-text">
           <span class="online-sheet__option-title">Random Opponent</span>
-          <span class="online-sheet__option-desc">Match with someone instantly</span>
+          <span class="online-sheet__option-desc">Match instantly, or join the queue</span>
         </div>
       </button>
 
       <!-- Join With Code -->
-      <div class="online-sheet__option online-sheet__option--code">
+      <div
+        class="online-sheet__option online-sheet__option--code"
+        role="group"
+        aria-labelledby="online-sheet-code-title"
+      >
         <div class="online-sheet__option-header">
           <div class="online-sheet__option-icon-box">
             <span class="material-symbols-outlined">key</span>
           </div>
           <div class="online-sheet__option-text">
-            <span class="online-sheet__option-title">Join With Code</span>
+            <span class="online-sheet__option-title" id="online-sheet-code-title">Join With Code</span>
             <span class="online-sheet__option-desc">Enter a shared invite code</span>
           </div>
         </div>
@@ -130,26 +152,35 @@
           <input
             class="online-sheet__code-input"
             type="text"
+            inputmode="text"
+            autocapitalize="characters"
+            autocomplete="off"
+            autocorrect="off"
+            spellcheck="false"
             placeholder="e.g. AB12CD"
             aria-label="Enter invite code"
-            maxlength="6"
+            [attr.maxlength]="codeLength"
             [(ngModel)]="inviteCode"
-            (input)="inviteCode = inviteCode.toUpperCase()"
+            (keyup)="onCodeKeyup()"
             (keyup.enter)="joinByCode()"
           />
           <button
             class="online-sheet__code-btn"
             (click)="joinByCode()"
-            [disabled]="loading() || inviteCode.length < 6"
+            [disabled]="loading() || !canSubmitCode()"
           >
-            Join
+            @if (pendingAction() === 'code') {
+              <span class="online-sheet__spinner online-sheet__spinner--on-accent" aria-hidden="true"></span>
+            } @else {
+              <span>Join</span>
+            }
           </button>
         </div>
       </div>
     </div>
 
     @if (error()) {
-      <p class="online-sheet__error">{{ error() }}</p>
+      <p class="online-sheet__error" role="alert">{{ error() }}</p>
     }
   </div>
 }

--- a/frontend/src/app/features/online-game/online-lobby.ts
+++ b/frontend/src/app/features/online-game/online-lobby.ts
@@ -3,20 +3,31 @@ import {
   inject,
   signal,
   OnInit,
+  OnDestroy,
   ChangeDetectionStrategy,
   HostListener,
   ElementRef,
   viewChild,
+  DestroyRef,
 } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
+import { Router, NavigationEnd } from '@angular/router';
 import { A11yModule } from '@angular/cdk/a11y';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { filter } from 'rxjs/operators';
 import { firstValueFrom } from 'rxjs';
 import { OnlineGameApiService, OnlineGameSummary } from '../../core/online-game-api.service';
 import { AuthService } from '../../core/auth.service';
 import { LanguageService } from '../../core/language.service';
 import { EmptyStateComponent } from '../../shared/empty-state/empty-state';
+
+/** Invite-code length is a server contract. If the server changes it, this changes. */
+const INVITE_CODE_LENGTH = 6;
+/** How often the lobby re-computes turn-deadline labels so "2m left" visibly ticks. */
+const DEADLINE_TICK_MS = 30_000;
+
+type PendingAction = 'create' | 'queue' | 'code' | null;
 
 @Component({
   selector: 'app-online-lobby',
@@ -26,25 +37,66 @@ import { EmptyStateComponent } from '../../shared/empty-state/empty-state';
   styleUrl: './online-lobby.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class OnlineLobbyComponent implements OnInit {
+export class OnlineLobbyComponent implements OnInit, OnDestroy {
   private api = inject(OnlineGameApiService);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
   auth = inject(AuthService);
   lang = inject(LanguageService);
 
+  readonly codeLength = INVITE_CODE_LENGTH;
+
   activeGames = signal<OnlineGameSummary[]>([]);
-  loading = signal(false);
+  hasLoaded = signal(false);
+  loadError = signal<string | null>(null);
   error = signal<string | null>(null);
   inviteCode = '';
   gameCount = signal(0);
   isPro = signal(false);
+  maxGames = signal(2);
   atLimit = signal(false);
   showPlaySheet = signal(false);
+  pendingAction = signal<PendingAction>(null);
+  /** Seconds since epoch, updated on an interval so deadline labels re-render. */
+  now = signal(Date.now());
+
+  private tickHandle: ReturnType<typeof setInterval> | null = null;
+  /** Set when a successful action triggers navigation — suppresses post-close focus restore. */
+  private navigating = false;
 
   /** Sheet trigger — used to restore focus when sheet closes. */
   playButton = viewChild<ElementRef<HTMLButtonElement>>('playButton');
 
+  /** Template helper: any action in flight. */
+  loading = (): boolean => this.pendingAction() !== null;
+
   ngOnInit(): void {
+    this.refresh();
+
+    this.tickHandle = setInterval(() => this.now.set(Date.now()), DEADLINE_TICK_MS);
+
+    // Re-fetch when the user re-enters the lobby via router.
+    this.router.events
+      .pipe(
+        filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((e) => {
+        if (e.urlAfterRedirects.startsWith('/online-lobby')) this.refresh();
+      });
+  }
+
+  ngOnDestroy(): void {
+    if (this.tickHandle) clearInterval(this.tickHandle);
+  }
+
+  /** Re-fetch when the tab becomes visible — opponent may have moved while we were away. */
+  @HostListener('document:visibilitychange')
+  onVisibility(): void {
+    if (document.visibilityState === 'visible') this.refresh();
+  }
+
+  private refresh(): void {
     this.loadGames();
     this.loadCount();
   }
@@ -53,97 +105,127 @@ export class OnlineLobbyComponent implements OnInit {
     try {
       const games = await firstValueFrom(this.api.listMyGames());
       this.activeGames.set(games);
+      this.loadError.set(null);
     } catch {
-      // ignore
+      this.loadError.set("Couldn't load your games. Pull to retry.");
+    } finally {
+      this.hasLoaded.set(true);
     }
   }
 
   private async loadCount(): Promise<void> {
     try {
-      const { count, isPro } = await firstValueFrom(this.api.getGameCount());
+      const { count, isPro, max } = await firstValueFrom(this.api.getGameCount());
       this.gameCount.set(count);
       this.isPro.set(isPro);
-      this.atLimit.set(!isPro && count >= 2);
+      this.maxGames.set(max);
+      this.atLimit.set(!isPro && max > 0 && count >= max);
     } catch {
-      // ignore
+      // Leave prior state; loadGames surfaces the user-facing error.
     }
   }
 
+  retryLoad(): void {
+    this.loadError.set(null);
+    this.hasLoaded.set(false);
+    this.refresh();
+  }
+
   openPlaySheet(): void {
+    this.error.set(null);
     this.showPlaySheet.set(true);
   }
 
   closePlaySheet(): void {
     this.showPlaySheet.set(false);
     this.error.set(null);
-    // Restore focus to the trigger button after close
+    if (this.navigating) return;
+    // Restore focus to the trigger only when the component is still active.
     queueMicrotask(() => this.playButton()?.nativeElement.focus());
   }
 
   @HostListener('document:keydown.escape')
   onEscape(): void {
-    if (this.showPlaySheet()) {
-      this.closePlaySheet();
-    }
+    if (this.showPlaySheet()) this.closePlaySheet();
   }
 
   async createGame(): Promise<void> {
-    this.loading.set(true);
+    if (this.loading()) return;
+    this.pendingAction.set('create');
     this.error.set(null);
     try {
       const game = await firstValueFrom(this.api.createGame());
+      this.navigating = true;
       this.showPlaySheet.set(false);
       this.router.navigate(['/online-game', game.id]);
     } catch (err: unknown) {
-      const msg = (err as { error?: { message?: string } })?.error?.message;
-      if (msg === 'MAX_ONLINE_GAMES_REACHED') this.error.set('You already have 2 active games.');
-      else if (msg === 'POOL_MISSING_SLOTS') this.error.set('Question pool is being refreshed. Please try again in a moment.');
-      else this.error.set('Failed to create game.');
+      this.error.set(this.mapError(err, 'Failed to create game.'));
     } finally {
-      this.loading.set(false);
+      this.pendingAction.set(null);
     }
   }
 
   async joinQueue(): Promise<void> {
-    this.loading.set(true);
+    if (this.loading()) return;
+    this.pendingAction.set('queue');
     this.error.set(null);
     try {
       const game = await firstValueFrom(this.api.joinQueue());
+      this.navigating = true;
       this.showPlaySheet.set(false);
       this.router.navigate(['/online-game', game.id]);
     } catch (err: unknown) {
-      const msg = (err as { error?: { message?: string } })?.error?.message;
-      if (msg === 'MAX_ONLINE_GAMES_REACHED') this.error.set('You already have 2 active games.');
-      else if (msg === 'POOL_MISSING_SLOTS') this.error.set('Question pool is being refreshed. Please try again in a moment.');
-      else this.error.set('Failed to join queue.');
+      this.error.set(this.mapError(err, 'Failed to join queue.'));
     } finally {
-      this.loading.set(false);
+      this.pendingAction.set(null);
     }
   }
 
   async joinByCode(): Promise<void> {
-    const code = this.inviteCode.trim();
-    if (code.length < 6) return;
-    this.loading.set(true);
+    if (this.loading()) return;
+    // Strip anything that isn't alphanumeric (users paste "AB-12-CD" or "ab 12 cd").
+    const code = this.inviteCode.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+    if (code.length !== INVITE_CODE_LENGTH) return;
+    this.inviteCode = code;
+    this.pendingAction.set('code');
     this.error.set(null);
     try {
       const game = await firstValueFrom(this.api.joinByCode(code));
+      this.navigating = true;
       this.showPlaySheet.set(false);
       this.router.navigate(['/online-game', game.id]);
     } catch (err: unknown) {
-      const body = (err as { error?: { message?: string } })?.error;
-      if (body?.message === 'MAX_ONLINE_GAMES_REACHED') {
-        this.error.set('You already have 2 active games.');
-      } else if (body?.message === 'POOL_MISSING_SLOTS') {
-        this.error.set('Question pool is being refreshed. Please try again in a moment.');
-      } else if (body?.message?.includes('not found')) {
-        this.error.set('Invite code not found. Check and try again.');
-      } else {
-        this.error.set('Failed to join game.');
-      }
+      this.error.set(this.mapError(err, 'Failed to join game.', true));
     } finally {
-      this.loading.set(false);
+      this.pendingAction.set(null);
     }
+  }
+
+  private mapError(err: unknown, fallback: string, isCode = false): string {
+    const msg = (err as { error?: { message?: string } })?.error?.message;
+    if (msg === 'MAX_ONLINE_GAMES_REACHED') {
+      const max = this.maxGames();
+      return max > 0
+        ? `You already have ${max} active games.`
+        : 'You have too many active games.';
+    }
+    if (msg === 'POOL_MISSING_SLOTS') {
+      return 'Question pool is being refreshed. Please try again in a moment.';
+    }
+    if (isCode && msg?.includes('not found')) {
+      return 'Invite code not found. Check and try again.';
+    }
+    return fallback;
+  }
+
+  /** Keystroke-safe: invoked from (keyup) so the synchronous cursor doesn't fight Android IMEs. */
+  onCodeKeyup(): void {
+    const cleaned = this.inviteCode.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+    if (cleaned !== this.inviteCode) this.inviteCode = cleaned;
+  }
+
+  canSubmitCode(): boolean {
+    return this.inviteCode.replace(/[^A-Za-z0-9]/g, '').length === INVITE_CODE_LENGTH;
   }
 
   resumeGame(gameId: string): void {
@@ -154,14 +236,29 @@ export class OnlineLobbyComponent implements OnInit {
     this.router.navigate(['/']);
   }
 
+  isExpired(game: OnlineGameSummary): boolean {
+    if (!game.turnDeadline) return false;
+    // Read `now()` so the template re-runs this on each tick.
+    return new Date(game.turnDeadline).getTime() - this.now() <= 0;
+  }
+
   turnBadgeClass(game: OnlineGameSummary): string {
+    if (this.isExpired(game)) return 'online-active-game__badge--expired';
     if (game.isMyTurn) return 'online-active-game__badge--my-turn';
     if (game.status === 'waiting' || game.status === 'queued') return 'online-active-game__badge--waiting';
     return 'online-active-game__badge--their-turn';
   }
 
+  turnBadgeLabel(game: OnlineGameSummary): string {
+    if (this.isExpired(game)) return 'Expired';
+    if (game.isMyTurn) return 'Your Turn';
+    if (game.status === 'waiting') return 'Waiting';
+    if (game.status === 'queued') return 'Queued';
+    return 'Their Turn';
+  }
+
   formatDeadline(iso: string): string {
-    const ms = new Date(iso).getTime() - Date.now();
+    const ms = new Date(iso).getTime() - this.now();
     if (ms <= 0) return 'Expired';
     const h = Math.floor(ms / 3600000);
     const m = Math.floor((ms % 3600000) / 60000);

--- a/frontend/src/app/features/online-game/online-lobby.ts
+++ b/frontend/src/app/features/online-game/online-lobby.ts
@@ -63,6 +63,8 @@ export class OnlineLobbyComponent implements OnInit, OnDestroy {
   private tickHandle: ReturnType<typeof setInterval> | null = null;
   /** Set when a successful action triggers navigation — suppresses post-close focus restore. */
   private navigating = false;
+  /** Epoch ms of the last successful refresh; debounces visibilitychange spam. */
+  private lastRefreshAt = 0;
 
   /** Sheet trigger — used to restore focus when sheet closes. */
   playButton = viewChild<ElementRef<HTMLButtonElement>>('playButton');
@@ -76,13 +78,15 @@ export class OnlineLobbyComponent implements OnInit, OnDestroy {
     this.tickHandle = setInterval(() => this.now.set(Date.now()), DEADLINE_TICK_MS);
 
     // Re-fetch when the user re-enters the lobby via router.
+    // Match the exact lobby path (not child routes like /online-game/:id).
     this.router.events
       .pipe(
         filter((e): e is NavigationEnd => e instanceof NavigationEnd),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((e) => {
-        if (e.urlAfterRedirects.startsWith('/online-lobby')) this.refresh();
+        const path = e.urlAfterRedirects.split('?')[0].replace(/\/$/, '');
+        if (path === '/online-game') this.refresh();
       });
   }
 
@@ -93,10 +97,14 @@ export class OnlineLobbyComponent implements OnInit, OnDestroy {
   /** Re-fetch when the tab becomes visible — opponent may have moved while we were away. */
   @HostListener('document:visibilitychange')
   onVisibility(): void {
-    if (document.visibilityState === 'visible') this.refresh();
+    if (document.visibilityState !== 'visible') return;
+    // Debounce rapid foreground/background toggles (min 15s between fetches).
+    if (Date.now() - this.lastRefreshAt < 15_000) return;
+    this.refresh();
   }
 
   private refresh(): void {
+    this.lastRefreshAt = Date.now();
     this.loadGames();
     this.loadCount();
   }


### PR DESCRIPTION
## Summary
Follow-up to #49. Resolves 13 issues surfaced by a CEO-mode review of the redesigned online lobby — silent failure modes, stale state, Android IME regression, server-truth gating, a11y inconsistency, and UX feedback gaps.

### Critical
- **Silent load failure → user-visible retry.** `listMyGames()`/`getGameCount()` no longer swallow errors; a retry card replaces the fake "No active games" state when fetching fails.
- **Stale lobby on re-entry.** Re-fetches on `document:visibilitychange` (foreground) and router `NavigationEnd` back to `/online-lobby`. Handles the mobile background/opponent-moves/return loop.
- **Android IME regression.** Removed `(input)="inviteCode = inviteCode.toUpperCase()"` which broke Gboard composition. Normalization moved to `(keyup)` with CSS `text-transform: uppercase` for visual feedback.

### High
- **Deadline labels now tick.** `now` signal updates every 30s; `formatDeadline()` + new `isExpired()` re-run under OnPush.
- **Copy fix.** "Match with someone instantly" → "Match instantly, or join the queue" (matchmaking can land in `queued`).
- **A11y: Join With Code.** Now `role="group"` + `aria-labelledby` so screen readers get a cohesive group announcement alongside the two sibling buttons.
- **Server-truth gating.** Backend `/count` returns `{ count, isPro, max }`. Frontend uses `max` for the cap, the limit banner copy, and the error message (`You already have ${max} active games.`). No more hard-coded `2`.

### Medium / Low
- `joinByCode` strips non-alphanumerics before submit (handles `AB-12-CD` pastes).
- Skeleton placeholder during initial fetch — no empty-state flash for users with active games.
- Per-action inline spinners on sheet buttons while a request is in flight.
- Expired turns render an `Expired` badge (new variant) instead of misleading `Your Turn`.
- `closePlaySheet()` suppresses focus-restore when an action has triggered navigation.
- `INVITE_CODE_LENGTH` extracted; `maxlength` and submit validation share one constant.

## Test plan
- [ ] Free user with 0/1/2 active games — PLAY button gating matches server `max`
- [ ] Kill backend, reload lobby — retry card appears, retry works
- [ ] Background app → opponent plays → foreground — games refresh automatically
- [ ] Paste `ab-12-cd` into code input — normalizes to `AB12CD` and submits
- [ ] Android device: type in code input with Gboard — no cursor jumps or dropped chars
- [ ] Watch a turn deadline near expiry — label ticks every ~30s; flips to `Expired` badge
- [ ] Screen reader traverses sheet — three options announced with consistent semantics
- [ ] Tap Create/Random/Join — spinner appears in the tapped option; others stay disabled