### PR TITLE
feat(question-pool): structured taxonomy + classifier + competition metadata

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -3,6 +3,10 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [
+      { "include": "questions/classifiers/canonical-entities.cleaned.json", "outDir": "dist" }
+    ],
+    "watchAssets": true
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,8 @@
     "pool:extract-entities": "ts-node -r tsconfig-paths/register scripts/extract-canonical-entities.ts",
     "pool:review-entities": "ts-node -r tsconfig-paths/register scripts/review-canonical-entities.ts",
     "pool:backfill-taxonomy": "ts-node -r tsconfig-paths/register scripts/backfill-pool-taxonomy.ts",
+    "pool:extract-competitions": "ts-node -r tsconfig-paths/register scripts/extract-competition-metadata.ts",
+    "pool:seed-competitions": "ts-node -r tsconfig-paths/register scripts/seed-competition-metadata.ts",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,8 @@
     "pool:migrate-difficulty:verbose": "ts-node -r tsconfig-paths/register scripts/migrate-question-pool-difficulty.ts --verbose",
     "pool:transfer-to-questions-v1": "ts-node -r tsconfig-paths/register scripts/transfer-pool-to-questions-v1.ts",
     "pool:extract-entities": "ts-node -r tsconfig-paths/register scripts/extract-canonical-entities.ts",
+    "pool:review-entities": "ts-node -r tsconfig-paths/register scripts/review-canonical-entities.ts",
+    "pool:backfill-taxonomy": "ts-node -r tsconfig-paths/register scripts/backfill-pool-taxonomy.ts",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "pool:migrate-difficulty:apply": "ts-node -r tsconfig-paths/register scripts/migrate-question-pool-difficulty.ts --apply",
     "pool:migrate-difficulty:verbose": "ts-node -r tsconfig-paths/register scripts/migrate-question-pool-difficulty.ts --verbose",
     "pool:transfer-to-questions-v1": "ts-node -r tsconfig-paths/register scripts/transfer-pool-to-questions-v1.ts",
+    "pool:extract-entities": "ts-node -r tsconfig-paths/register scripts/extract-canonical-entities.ts",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/backend/scripts/backfill-pool-taxonomy.ts
+++ b/backend/scripts/backfill-pool-taxonomy.ts
@@ -35,6 +35,7 @@ interface Args {
   limit: number | null;
   apply: boolean;
   concurrency: number;
+  resume: boolean;
 }
 
 function parseArgs(): Args {
@@ -49,6 +50,7 @@ function parseArgs(): Args {
     limit: get('--limit') ? Number(get('--limit')) : null,
     apply: has('--apply'),
     concurrency: Number(get('--concurrency') ?? 3),
+    resume: has('--resume'),
   };
 }
 
@@ -94,15 +96,33 @@ async function fetchStratified(
 
 async function fetchFlat(
   supabase: SupabaseService,
-  limit: number | null
+  limit: number | null,
+  onlyUnclassified: boolean
 ): Promise<PoolRow[]> {
-  const q = supabase.client
-    .from('question_pool')
-    .select('id, category, difficulty, question')
-    .neq('category', 'LOGO_QUIZ');
-  const { data, error } = limit ? await q.limit(limit) : await q;
-  if (error) throw error;
-  return (data ?? []) as PoolRow[];
+  // Supabase caps a single select at 1000 rows by default. Paginate with range()
+  // so --limit null = "everything" actually means everything.
+  const PAGE = 1000;
+  const all: PoolRow[] = [];
+  let from = 0;
+  const cap = limit ?? Number.POSITIVE_INFINITY;
+
+  while (all.length < cap) {
+    const pageSize = Math.min(PAGE, cap - all.length);
+    let q = supabase.client
+      .from('question_pool')
+      .select('id, category, difficulty, question')
+      .neq('category', 'LOGO_QUIZ')
+      .order('id', { ascending: true })
+      .range(from, from + pageSize - 1);
+    if (onlyUnclassified) q = q.is('subject_id', null);
+    const { data, error } = await q;
+    if (error) throw error;
+    const batch = (data ?? []) as PoolRow[];
+    all.push(...batch);
+    if (batch.length < pageSize) break;
+    from += pageSize;
+  }
+  return all;
 }
 
 async function runWithConcurrency<T, R>(
@@ -256,8 +276,8 @@ async function main(): Promise<void> {
     console.log('Fetching stratified pilot sample (~25 questions)...');
     rows = await fetchStratified(supabase, 4); // 7 cats × 4 ≈ 28
   } else {
-    console.log(`Fetching ${args.limit ?? 'all'} questions...`);
-    rows = await fetchFlat(supabase, args.limit);
+    console.log(`Fetching ${args.limit ?? 'all'} questions${args.resume ? ' (resume mode — only rows with subject_id IS NULL)' : ''}...`);
+    rows = await fetchFlat(supabase, args.limit, args.resume);
   }
   console.log(`  ${rows.length} questions.`);
 

--- a/backend/scripts/backfill-pool-taxonomy.ts
+++ b/backend/scripts/backfill-pool-taxonomy.ts
@@ -71,14 +71,26 @@ async function fetchStratified(
   supabase: SupabaseService,
   perCategory: number
 ): Promise<PoolRow[]> {
-  // Distinct non-logo categories. Not using RPC — simple client-side sample is fine.
-  const { data, error } = await supabase.client
-    .from('question_pool')
-    .select('id, category, difficulty, question')
-    .neq('category', 'LOGO_QUIZ');
-  if (error) throw error;
+  // Paginate the full non-logo pool so stratification isn't biased by the
+  // first 1000 rows.
+  const PAGE = 1000;
+  const all: PoolRow[] = [];
+  let from = 0;
+  while (true) {
+    const { data, error } = await supabase.client
+      .from('question_pool')
+      .select('id, category, difficulty, question')
+      .neq('category', 'LOGO_QUIZ')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw error;
+    const batch = (data ?? []) as PoolRow[];
+    all.push(...batch);
+    if (batch.length < PAGE) break;
+    from += PAGE;
+  }
   const byCat = new Map<string, PoolRow[]>();
-  for (const r of (data ?? []) as PoolRow[]) {
+  for (const r of all) {
     if (!byCat.has(r.category)) byCat.set(r.category, []);
     byCat.get(r.category)!.push(r);
   }

--- a/backend/scripts/backfill-pool-taxonomy.ts
+++ b/backend/scripts/backfill-pool-taxonomy.ts
@@ -262,9 +262,10 @@ async function maybeApply(
         valid_until: c.valid_until,
         tags: c.tags.length ? c.tags : null,
         // league_tier + competition_type now filled by the competition_metadata
-        // trigger. era is a generated column. Only event_year remains
+        // trigger. era is a generated column. event_year + nationality remain
         // classifier-sourced.
         event_year: c.event_year,
+        nationality: c.nationality,
       })
       .eq('id', r.question_id);
     if (error) console.error(`  update ${r.question_id} failed:`, error.message);

--- a/backend/scripts/backfill-pool-taxonomy.ts
+++ b/backend/scripts/backfill-pool-taxonomy.ts
@@ -249,6 +249,10 @@ async function maybeApply(
         time_sensitive: c.time_sensitive,
         valid_until: c.valid_until,
         tags: c.tags.length ? c.tags : null,
+        league_tier: c.league_tier,
+        competition_type: c.competition_type,
+        era: c.era,
+        event_year: c.event_year,
       })
       .eq('id', r.question_id);
     if (error) console.error(`  update ${r.question_id} failed:`, error.message);

--- a/backend/scripts/backfill-pool-taxonomy.ts
+++ b/backend/scripts/backfill-pool-taxonomy.ts
@@ -1,0 +1,306 @@
+#!/usr/bin/env npx ts-node
+/* eslint-disable no-undef, no-console */
+/**
+ * Backfill the taxonomy columns on question_pool using the
+ * QuestionClassifierService. The canonical entity list is embedded in the
+ * classifier's system prompt; any slug Gemini returns that isn't in the list
+ * is rejected post-call.
+ *
+ * --pilot             run a stratified sample (~25 questions) and write
+ *                     results to _backfill-pool/pilot-output.* — DB UNTOUCHED.
+ * --limit N           run on N questions (DB UNTOUCHED unless --apply).
+ * --apply             actually write classifications back to question_pool.
+ *                     Required for full runs. Pilot always dry-runs.
+ * --concurrency N     parallel Gemini calls (default 3).
+ *
+ * Examples:
+ *   npm run pool:backfill-taxonomy -- --pilot
+ *   npm run pool:backfill-taxonomy -- --limit 100            # dry run
+ *   npm run pool:backfill-taxonomy -- --apply                # full run, writes DB
+ */
+import { NestFactory } from '@nestjs/core';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AppModule } from '../src/app.module';
+import { SupabaseService } from '../src/supabase/supabase.service';
+import {
+  QuestionClassifierService,
+  ClassifierInput,
+  ClassifierResult,
+} from '../src/questions/classifiers/question-classifier.service';
+import { loadCanonicalEntities } from '../src/questions/classifiers/canonical-entities';
+
+interface Args {
+  pilot: boolean;
+  limit: number | null;
+  apply: boolean;
+  concurrency: number;
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  const has = (f: string): boolean => args.includes(f);
+  const get = (f: string): string | undefined => {
+    const i = args.indexOf(f);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  return {
+    pilot: has('--pilot'),
+    limit: get('--limit') ? Number(get('--limit')) : null,
+    apply: has('--apply'),
+    concurrency: Number(get('--concurrency') ?? 3),
+  };
+}
+
+const OUT_DIR = path.resolve(__dirname, '_backfill-pool');
+
+interface PoolRow {
+  id: string;
+  category: string;
+  difficulty: string | null;
+  question: {
+    question_text?: string;
+    correct_answer?: string;
+    explanation?: string;
+  };
+}
+
+async function fetchStratified(
+  supabase: SupabaseService,
+  perCategory: number
+): Promise<PoolRow[]> {
+  // Distinct non-logo categories. Not using RPC — simple client-side sample is fine.
+  const { data, error } = await supabase.client
+    .from('question_pool')
+    .select('id, category, difficulty, question')
+    .neq('category', 'LOGO_QUIZ');
+  if (error) throw error;
+  const byCat = new Map<string, PoolRow[]>();
+  for (const r of (data ?? []) as PoolRow[]) {
+    if (!byCat.has(r.category)) byCat.set(r.category, []);
+    byCat.get(r.category)!.push(r);
+  }
+  const out: PoolRow[] = [];
+  for (const [, list] of byCat) {
+    // Shuffle in place (Fisher-Yates) and take N.
+    for (let i = list.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [list[i], list[j]] = [list[j], list[i]];
+    }
+    out.push(...list.slice(0, perCategory));
+  }
+  return out;
+}
+
+async function fetchFlat(
+  supabase: SupabaseService,
+  limit: number | null
+): Promise<PoolRow[]> {
+  const q = supabase.client
+    .from('question_pool')
+    .select('id, category, difficulty, question')
+    .neq('category', 'LOGO_QUIZ');
+  const { data, error } = limit ? await q.limit(limit) : await q;
+  if (error) throw error;
+  return (data ?? []) as PoolRow[];
+}
+
+async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, idx: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (err) {
+        console.error(`  item ${idx} failed:`, (err as Error).message);
+        results[idx] = undefined as unknown as R;
+      }
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+function toClassifierInput(row: PoolRow): ClassifierInput {
+  return {
+    id: row.id,
+    category: row.category,
+    difficulty: row.difficulty ?? undefined,
+    question_text: row.question.question_text ?? '',
+    correct_answer: row.question.correct_answer ?? '',
+    explanation: row.question.explanation,
+  };
+}
+
+function escHtml(s: string): string {
+  return String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c] as string));
+}
+
+function renderPilotHtml(rows: PoolRow[], results: ClassifierResult[]): string {
+  const cards = rows
+    .map((row, i) => {
+      const r = results[i];
+      if (!r) {
+        return `<div class="card err"><div class="qid">${escHtml(row.id)}</div><div class="fail">CLASSIFICATION FAILED</div></div>`;
+      }
+      const c = r.classification;
+      const warns = r.warnings.length
+        ? `<div class="warn">⚠ ${r.warnings.map(escHtml).join('; ')}</div>`
+        : '';
+      const tags = c.tags.length ? c.tags.map((t) => `<code>${escHtml(t)}</code>`).join(' ') : '<span class="dim">—</span>';
+      const modes = c.mode_compatibility.length ? c.mode_compatibility.join(', ') : '<span class="dim">(none)</span>';
+      return `<div class="card">
+        <div class="q"><strong>Q:</strong> ${escHtml(row.question.question_text ?? '')}</div>
+        <div class="a"><strong>A:</strong> ${escHtml(row.question.correct_answer ?? '')}</div>
+        <div class="meta">${escHtml(row.category)}${row.difficulty ? ' · ' + escHtml(row.difficulty) : ''} · <code>${escHtml(row.id.slice(0, 8))}</code></div>
+        ${warns}
+        <table class="tax">
+          <tr><th>subject_type</th><td>${c.subject_type ? '<code>' + escHtml(c.subject_type) + '</code>' : '<span class="dim">null</span>'}</td></tr>
+          <tr><th>subject_id</th><td>${c.subject_id ? '<code>' + escHtml(c.subject_id) + '</code>' : '<span class="dim">null</span>'}</td></tr>
+          <tr><th>subject_name</th><td>${c.subject_name ? escHtml(c.subject_name) : '<span class="dim">null</span>'}</td></tr>
+          <tr><th>competition_id</th><td>${c.competition_id ? '<code>' + escHtml(c.competition_id) + '</code>' : '<span class="dim">null</span>'}</td></tr>
+          <tr><th>question_style</th><td>${c.question_style ? '<code>' + escHtml(c.question_style) + '</code>' : '<span class="dim">null</span>'}</td></tr>
+          <tr><th>answer_type</th><td>${c.answer_type ? '<code>' + escHtml(c.answer_type) + '</code>' : '<span class="dim">null</span>'}</td></tr>
+          <tr><th>mode_compatibility</th><td>${modes}</td></tr>
+          <tr><th>concept_id</th><td>${c.concept_id ? '<code>' + escHtml(c.concept_id) + '</code>' : '<span class="dim">null</span>'}</td></tr>
+          <tr><th>popularity_score</th><td>${c.popularity_score ?? '<span class="dim">null</span>'}</td></tr>
+          <tr><th>time_sensitive</th><td>${c.time_sensitive ? 'true' : 'false'}${c.valid_until ? ' · valid_until ' + escHtml(c.valid_until) : ''}</td></tr>
+          <tr><th>tags</th><td>${tags}</td></tr>
+        </table>
+      </div>`;
+    })
+    .join('');
+
+  const warnCount = results.filter((r) => r && r.warnings.length > 0).length;
+  const failCount = results.filter((r) => !r).length;
+
+  return `<!doctype html><html><head><meta charset="utf-8"><title>Backfill pilot review</title>
+<style>
+  body { font: 14px/1.5 -apple-system, system-ui, sans-serif; margin: 0; background: #fafafa; color: #111; }
+  header { background: #fff; border-bottom: 1px solid #e5e7eb; padding: 1rem 1.5rem; position: sticky; top: 0; }
+  main { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
+  .card { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: .75rem; }
+  .card.err { border-color: #dc2626; background: #fef2f2; }
+  .fail { color: #dc2626; font-weight: 600; }
+  .q { font-size: 1.02em; margin-bottom: .2rem; }
+  .a { color: #059669; margin-bottom: .3rem; }
+  .meta { color: #6b7280; font-size: .85em; margin-bottom: .5rem; }
+  .warn { background: #fef3c7; color: #78350f; padding: .3rem .6rem; border-radius: 4px; font-size: .85em; margin-bottom: .5rem; }
+  table.tax { width: 100%; border-collapse: collapse; font-size: .9em; }
+  table.tax th { text-align: left; width: 160px; padding: .25rem .5rem; color: #475569; font-weight: 500; border-bottom: 1px solid #f1f5f9; }
+  table.tax td { padding: .25rem .5rem; border-bottom: 1px solid #f1f5f9; }
+  code { background: #f1f5f9; padding: 1px 6px; border-radius: 3px; font-family: ui-monospace, Menlo, monospace; font-size: .88em; }
+  .dim { color: #9ca3af; }
+</style></head><body>
+<header><strong>Backfill pilot review</strong> · ${rows.length} questions · ${warnCount} with warnings · ${failCount} failed</header>
+<main>${cards}</main>
+</body></html>`;
+}
+
+async function maybeApply(
+  supabase: SupabaseService,
+  results: ClassifierResult[],
+  apply: boolean
+): Promise<number> {
+  if (!apply) return 0;
+  let updated = 0;
+  for (const r of results) {
+    if (!r) continue;
+    const c = r.classification;
+    const { error } = await supabase.client
+      .from('question_pool')
+      .update({
+        subject_type: c.subject_type,
+        subject_id: c.subject_id,
+        subject_name: c.subject_name,
+        competition_id: c.competition_id,
+        question_style: c.question_style,
+        answer_type: c.answer_type,
+        mode_compatibility: c.mode_compatibility.length ? c.mode_compatibility : null,
+        concept_id: c.concept_id,
+        popularity_score: c.popularity_score,
+        time_sensitive: c.time_sensitive,
+        valid_until: c.valid_until,
+        tags: c.tags.length ? c.tags : null,
+      })
+      .eq('id', r.question_id);
+    if (error) console.error(`  update ${r.question_id} failed:`, error.message);
+    else updated++;
+  }
+  return updated;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  const supabase = app.get(SupabaseService);
+  const classifier = app.get(QuestionClassifierService);
+
+  console.log('Loading canonical entity list...');
+  const canonical = loadCanonicalEntities();
+  console.log(`  ${canonical.all.length} entities loaded across ${canonical.byType.size} types.`);
+
+  let rows: PoolRow[];
+  if (args.pilot) {
+    console.log('Fetching stratified pilot sample (~25 questions)...');
+    rows = await fetchStratified(supabase, 4); // 7 cats × 4 ≈ 28
+  } else {
+    console.log(`Fetching ${args.limit ?? 'all'} questions...`);
+    rows = await fetchFlat(supabase, args.limit);
+  }
+  console.log(`  ${rows.length} questions.`);
+
+  if (rows.length === 0) {
+    await app.close();
+    return;
+  }
+
+  console.log(`Classifying with concurrency ${args.concurrency}...`);
+  const inputs = rows.map(toClassifierInput);
+  const results = await runWithConcurrency(inputs, args.concurrency, async (input, idx) => {
+    const res = await classifier.classify(input, canonical);
+    process.stdout.write(`  ${idx + 1}/${inputs.length} ${res.warnings.length ? '⚠' : '✓'}\n`);
+    return res;
+  });
+
+  const okResults = results.filter((r): r is ClassifierResult => !!r);
+  const warnings = okResults.filter((r) => r.warnings.length > 0).length;
+  const fails = results.length - okResults.length;
+
+  if (args.pilot || !args.apply) {
+    const jsonPath = path.join(OUT_DIR, 'pilot-output.json');
+    const htmlPath = path.join(OUT_DIR, 'pilot-review.html');
+    fs.writeFileSync(
+      jsonPath,
+      JSON.stringify(
+        { generated_at: new Date().toISOString(), count: rows.length, results: okResults },
+        null,
+        2
+      )
+    );
+    fs.writeFileSync(htmlPath, renderPilotHtml(rows, results));
+    console.log(`\nDry-run written to:\n  ${jsonPath}\n  ${htmlPath}`);
+  } else {
+    const applied = await maybeApply(supabase, okResults, true);
+    console.log(`\nApplied ${applied}/${okResults.length} updates to question_pool.`);
+  }
+
+  console.log(`\nSummary: ${okResults.length} classified, ${warnings} with warnings, ${fails} failed.`);
+  await app.close();
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/backend/scripts/backfill-pool-taxonomy.ts
+++ b/backend/scripts/backfill-pool-taxonomy.ts
@@ -249,9 +249,9 @@ async function maybeApply(
         time_sensitive: c.time_sensitive,
         valid_until: c.valid_until,
         tags: c.tags.length ? c.tags : null,
-        league_tier: c.league_tier,
-        competition_type: c.competition_type,
-        era: c.era,
+        // league_tier + competition_type now filled by the competition_metadata
+        // trigger. era is a generated column. Only event_year remains
+        // classifier-sourced.
         event_year: c.event_year,
       })
       .eq('id', r.question_id);

--- a/backend/scripts/extract-canonical-entities.ts
+++ b/backend/scripts/extract-canonical-entities.ts
@@ -1,0 +1,313 @@
+#!/usr/bin/env npx ts-node
+/* eslint-disable no-undef, no-console */
+/**
+ * Extract canonical football entities (players, teams, leagues, trophies, managers, stadiums)
+ * from existing question_pool rows using Gemini. Output is a reviewable JSON list that will
+ * be passed into the backfill prompt as an enum constraint, preventing slug drift
+ * (e.g. "messi" vs "lionel-messi" vs "leo-messi" all pointing at the same entity).
+ *
+ * Run:
+ *   npm run db:extract-entities              (all questions, default limits)
+ *   npm run db:extract-entities -- --limit 200 --batch-size 30 --concurrency 3
+ *
+ * Output: backend/scripts/_backfill-pool/canonical-entities.json
+ *
+ * Human review pass: open the JSON, merge duplicates, fix wrong slugs, delete noise.
+ * The reviewed file becomes the source of truth for all subsequent backfill + generation.
+ */
+import { NestFactory } from '@nestjs/core';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AppModule } from '../src/app.module';
+import { SupabaseService } from '../src/supabase/supabase.service';
+import { LlmService } from '../src/llm/llm.service';
+
+type EntityType =
+  | 'player'
+  | 'team'
+  | 'league'
+  | 'trophy'
+  | 'manager'
+  | 'stadium'
+  | 'country';
+
+interface ExtractedEntity {
+  type: EntityType;
+  slug: string;
+  display_name: string;
+  aliases: string[];
+  question_ids: string[];
+}
+
+interface AggregatedEntity {
+  type: EntityType;
+  slug: string;
+  display_name: string;
+  aliases: string[];
+  mention_count: number;
+  sample_question_ids: string[];
+}
+
+interface QuestionRow {
+  id: string;
+  question: {
+    question_text?: string;
+    correct_answer?: string;
+    explanation?: string;
+  };
+}
+
+interface GeminiBatchOutput {
+  entities: Array<{
+    type: EntityType;
+    slug: string;
+    display_name: string;
+    aliases?: string[];
+    question_indices: number[];
+  }>;
+}
+
+const OUTPUT_DIR = path.resolve(__dirname, '_backfill-pool');
+const OUTPUT_FILE = path.join(OUTPUT_DIR, 'canonical-entities.json');
+const RAW_DEBUG_FILE = path.join(OUTPUT_DIR, 'canonical-entities.raw.jsonl');
+
+function parseArgs(): { limit?: number; batchSize: number; concurrency: number } {
+  const args = process.argv.slice(2);
+  const get = (flag: string): string | undefined => {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  return {
+    limit: get('--limit') ? Number(get('--limit')) : undefined,
+    batchSize: Number(get('--batch-size') ?? 30),
+    concurrency: Number(get('--concurrency') ?? 3),
+  };
+}
+
+const SYSTEM_PROMPT = `You are a football (soccer) entity extractor. Given a numbered batch of trivia questions, identify every distinct real-world football entity mentioned across ALL text fields (question_text, correct_answer, explanation).
+
+Entity types: player, team, league, trophy, manager, stadium, country.
+
+For each distinct entity in the batch, return ONE record with:
+- type: one of the allowed types above.
+- slug: canonical kebab-case identifier. Rules:
+    * lowercase, ASCII only, hyphens between words, no diacritics (ñ→n, é→e, ü→u)
+    * player: "<firstname-lastname>" e.g. "lionel-messi", "cristiano-ronaldo"
+    * team: Use the shortest widely-recognized common name. Do NOT append "-fc" / "-cf" / "-cb" suffixes.
+        Correct: "arsenal", "real-madrid", "liverpool", "ajax", "celtic", "sevilla", "marseille"
+        Correct (prefix is part of the recognized name): "fc-barcelona", "ac-milan", "inter-milan", "paris-saint-germain"
+        WRONG: "arsenal-fc", "liverpool-fc", "ajax-fc", "valencia-cf"
+    * league: official short slug e.g. "premier-league", "la-liga", "serie-a", "bundesliga", "ligue-1"
+    * trophy: "<trophy>" e.g. "uefa-champions-league", "ballon-dor", "fifa-world-cup", "europa-league"
+        Keep historically-distinct trophies separate: "european-cup" (pre-1992) and "uefa-champions-league" (post-1992) are different slugs.
+        Same for "uefa-cup" (pre-2009) vs "europa-league" (post-2009).
+    * manager: "<firstname-lastname>" e.g. "pep-guardiola"
+    * stadium: "<stadium-name>" e.g. "santiago-bernabeu", "old-trafford"
+    * country: ISO-alpha2 lowercase e.g. "gb", "es", "br" — NOT national football teams (a national team is a "team" entity)
+- display_name: full canonical name for UI ("Lionel Messi", "Arsenal", "FC Barcelona", "UEFA Champions League")
+- aliases: other names / nicknames that appear in the text or are widely known ("Leo Messi", "The Arsenal", "Los Blancos", "Gunners"). Up to 5. Do NOT repeat display_name.
+- question_indices: array of 1-based question numbers (from the [1], [2], ... markers in the user message) where this entity is mentioned. If Messi appears in questions 1, 3, and 7, return [1,3,7]. REQUIRED for every entity.
+
+Rules:
+- Only return entities that are explicitly named. Do not infer.
+- Use the SAME slug for the SAME real-world entity across all questions in the batch.
+- If a player and a team share a name, pick the one actually referenced.
+- Skip vague references ("a Premier League team", "the manager", "a German club") — not entities.
+- Return { "entities": [] } if no entities are found.`;
+
+async function extractEntitiesFromBatch(
+  llm: LlmService,
+  batch: QuestionRow[]
+): Promise<ExtractedEntity[]> {
+  const userPrompt = `Extract entities from these ${batch.length} questions:\n\n${batch
+    .map(
+      (q, i) =>
+        `[${i + 1}] Q: ${q.question.question_text ?? ''}\n    A: ${q.question.correct_answer ?? ''}${
+          q.question.explanation ? `\n    Context: ${q.question.explanation}` : ''
+        }`
+    )
+    .join(
+      '\n\n'
+    )}\n\nReturn JSON: { "entities": [ { type, slug, display_name, aliases, question_indices } ] }`;
+
+  const result = await llm.generateStructuredJson<GeminiBatchOutput>(
+    SYSTEM_PROMPT,
+    userPrompt,
+    3
+  );
+
+  return (result.entities ?? []).map((e) => {
+    const indices = Array.isArray(e.question_indices) ? e.question_indices : [];
+    const question_ids = indices
+      .filter((i) => Number.isInteger(i) && i >= 1 && i <= batch.length)
+      .map((i) => batch[i - 1].id);
+    return {
+      type: e.type,
+      slug: e.slug,
+      display_name: e.display_name,
+      aliases: e.aliases ?? [],
+      question_ids: Array.from(new Set(question_ids)),
+    };
+  });
+}
+
+function aggregate(
+  perBatch: Array<{ batch: QuestionRow[]; entities: ExtractedEntity[] }>
+): AggregatedEntity[] {
+  const byKey = new Map<
+    string,
+    {
+      type: EntityType;
+      slug: string;
+      display_name: string;
+      aliases: Set<string>;
+      question_ids: Set<string>;
+    }
+  >();
+
+  for (const { entities } of perBatch) {
+    for (const e of entities) {
+      const key = `${e.type}::${e.slug}`;
+      const existing = byKey.get(key);
+      if (existing) {
+        for (const a of e.aliases) existing.aliases.add(a);
+        for (const id of e.question_ids) existing.question_ids.add(id);
+      } else {
+        byKey.set(key, {
+          type: e.type,
+          slug: e.slug,
+          display_name: e.display_name,
+          aliases: new Set(e.aliases),
+          question_ids: new Set(e.question_ids),
+        });
+      }
+    }
+  }
+
+  return Array.from(byKey.values())
+    .map((v) => ({
+      type: v.type,
+      slug: v.slug,
+      display_name: v.display_name,
+      aliases: Array.from(v.aliases),
+      mention_count: v.question_ids.size,
+      sample_question_ids: Array.from(v.question_ids).slice(0, 5),
+    }))
+    .sort((a, b) => b.mention_count - a.mention_count);
+}
+
+async function runBatched<T, R>(
+  items: T[],
+  batchSize: number,
+  concurrency: number,
+  fn: (batch: T[], batchIndex: number) => Promise<R>
+): Promise<R[]> {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    batches.push(items.slice(i, i + batchSize));
+  }
+  const results: R[] = new Array(batches.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(concurrency, batches.length) }, async () => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= batches.length) return;
+      const batch = batches[idx];
+      try {
+        results[idx] = await fn(batch, idx);
+        console.log(`  batch ${idx + 1}/${batches.length} done (${batch.length} questions)`);
+      } catch (err) {
+        console.error(`  batch ${idx + 1} failed:`, (err as Error).message);
+        results[idx] = undefined as unknown as R;
+      }
+    }
+  });
+  await Promise.all(workers);
+  return results.filter((r) => r !== undefined);
+}
+
+async function main(): Promise<void> {
+  const { limit, batchSize, concurrency } = parseArgs();
+
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  const supabase = app.get(SupabaseService);
+  const llm = app.get(LlmService);
+
+  console.log('Loading questions from question_pool (excluding LOGO_QUIZ)...');
+
+  const query = supabase.client
+    .from('question_pool')
+    .select('id, question')
+    .neq('category', 'LOGO_QUIZ');
+  const { data, error } = limit ? await query.limit(limit) : await query;
+
+  if (error) {
+    console.error('Supabase error:', error);
+    await app.close();
+    process.exit(1);
+  }
+
+  const rows = (data ?? []) as QuestionRow[];
+  console.log(`Loaded ${rows.length} questions. Batch size ${batchSize}, concurrency ${concurrency}.`);
+
+  if (rows.length === 0) {
+    console.log('No questions to process.');
+    await app.close();
+    return;
+  }
+
+  fs.writeFileSync(RAW_DEBUG_FILE, '', 'utf8');
+
+  const batchResults = await runBatched(rows, batchSize, concurrency, async (batch) => {
+    const entities = await extractEntitiesFromBatch(llm, batch);
+    fs.appendFileSync(
+      RAW_DEBUG_FILE,
+      JSON.stringify({ batch_ids: batch.map((q) => q.id), entities }) + '\n',
+      'utf8'
+    );
+    return { batch, entities };
+  });
+
+  const aggregated = aggregate(batchResults);
+
+  const byType = aggregated.reduce<Record<string, AggregatedEntity[]>>((acc, e) => {
+    (acc[e.type] ??= []).push(e);
+    return acc;
+  }, {});
+
+  const summary = {
+    generated_at: new Date().toISOString(),
+    source: {
+      total_questions_scanned: rows.length,
+      batch_size: batchSize,
+      concurrency,
+    },
+    counts_by_type: Object.fromEntries(
+      Object.entries(byType).map(([type, list]) => [type, list.length])
+    ),
+    entities: aggregated,
+  };
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(summary, null, 2), 'utf8');
+
+  console.log(`\nDone. ${aggregated.length} unique entities written to:`);
+  console.log(`  ${OUTPUT_FILE}`);
+  console.log('  (raw per-batch output: canonical-entities.raw.jsonl)');
+  console.log('\nCounts by type:');
+  for (const [type, count] of Object.entries(summary.counts_by_type)) {
+    console.log(`  ${type.padEnd(10)} ${count}`);
+  }
+  console.log('\nNext: review the JSON, merge duplicates, fix wrong slugs, delete noise.');
+  console.log('The reviewed file feeds the backfill prompt as an enum constraint.');
+
+  await app.close();
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/backend/scripts/extract-competition-metadata.ts
+++ b/backend/scripts/extract-competition-metadata.ts
@@ -1,0 +1,279 @@
+#!/usr/bin/env npx ts-node
+/* eslint-disable no-undef, no-console */
+/**
+ * Build the competition_metadata source of truth from the reviewed canonical
+ * entity list. For every entity of type "league" or "trophy" we ask Gemini
+ * (with web search grounding) for the structured facts that powered the
+ * denormalised question_pool columns: prestige tier, competition type,
+ * country, founded/defunct years.
+ *
+ * Output is a reviewable JSON file you eyeball + hand-edit, then a separate
+ * migration seeds competition_metadata from it.
+ *
+ * Run:  npm run pool:extract-competitions
+ * Output: backend/scripts/_backfill-pool/competition-metadata.json
+ */
+import { NestFactory } from '@nestjs/core';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AppModule } from '../src/app.module';
+import { LlmService } from '../src/llm/llm.service';
+import {
+  CanonicalEntity,
+  loadCanonicalEntities,
+} from '../src/questions/classifiers/canonical-entities';
+
+const OUT_DIR = path.resolve(__dirname, '_backfill-pool');
+const OUT_FILE = path.join(OUT_DIR, 'competition-metadata.json');
+
+const ALLOWED_COMPETITION_TYPES = [
+  'domestic_league',
+  'domestic_cup',
+  'continental_club',
+  'international_national',
+  'youth',
+  'friendly',
+  'other',
+] as const;
+
+type CompetitionType = (typeof ALLOWED_COMPETITION_TYPES)[number];
+
+interface CompetitionMetadata {
+  id: string;
+  entity_type: 'league' | 'trophy';
+  display_name: string;
+  tier: number | null;
+  competition_type: CompetitionType | null;
+  country_code: string | null;
+  founded_year: number | null;
+  defunct_year: number | null;
+  warnings: string[];
+}
+
+interface GeminiBatchOutput {
+  competitions: Array<{
+    id: string;
+    tier: number | null;
+    competition_type: string | null;
+    country_code: string | null;
+    founded_year: number | null;
+    defunct_year: number | null;
+  }>;
+}
+
+function parseArgs(): { batchSize: number; concurrency: number } {
+  const args = process.argv.slice(2);
+  const get = (flag: string): string | undefined => {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  return {
+    batchSize: Number(get('--batch-size') ?? 20),
+    concurrency: Number(get('--concurrency') ?? 2),
+  };
+}
+
+const SYSTEM_PROMPT = `You are a football (soccer) competition reference. Given a batch of league/trophy canonical slugs with display names, return authoritative structured facts for each.
+
+For each competition return:
+- id: the exact slug from input (do not invent, do not reformat)
+- tier: integer 1..5 describing prestige
+    1 = top-5 EU domestic leagues (Premier League, La Liga, Serie A, Bundesliga, Ligue 1) OR the top-tier continental club trophy (UEFA Champions League) OR the global national-team trophy (FIFA World Cup)
+    2 = other major European top flights (Eredivisie, Primeira Liga, Süper Lig, etc.) OR secondary continental club trophy (UEFA Europa League, UEFA Cup Winners' Cup) OR top continental national-team trophy (UEFA Euro, Copa America)
+    3 = other notable professional leagues (MLS, Saudi Pro League, J1 League, Scottish Premiership, Russian Premier League, etc.) OR tertiary continental (UEFA Conference League) OR other regional national-team trophies
+    4 = lower national divisions (Championship, Serie B, Segunda División, etc.)
+    5 = youth / amateur / defunct minor / friendlies
+    Return null if genuinely unclassifiable.
+- competition_type: one of ["domestic_league","domestic_cup","continental_club","international_national","youth","friendly","other"]
+    domestic_league = national top flight or lower division
+    domestic_cup = national knockout cup (FA Cup, Copa del Rey, DFB-Pokal, Coppa Italia)
+    continental_club = UEFA / CONMEBOL / AFC / CAF club competition (Champions League, Europa League, Copa Libertadores)
+    international_national = national-team tournament (World Cup, Euro, Copa America, AFCON, Gold Cup)
+    youth = under-21 / U-17 etc.
+    friendly = non-competitive (Trophée des Champions is technically a super cup — use "other")
+    other = anything else (super cups, testimonial, etc.)
+- country_code: ISO alpha-2 lowercase code for the HOST country of a domestic competition (e.g. "gb" for Premier League, "es" for La Liga, "gr" for Greek Super League). NULL for continental or international competitions (UEFA Champions League, FIFA World Cup — no single host country).
+- founded_year: integer 1850..current_year. Year the competition was founded / first edition. NULL if unknown.
+- defunct_year: integer, ONLY if the competition no longer exists (e.g. UEFA Cup Winners' Cup ended 1999, European Cup rebranded to UEFA Champions League in 1992 — use 1992 for "european-cup"). NULL for still-active competitions.
+
+Return JSON: { "competitions": [ {id, tier, competition_type, country_code, founded_year, defunct_year}, ... ] }
+
+Rules:
+- Return one record per input slug, preserving the slug verbatim.
+- For trophies that are the same competition rebranded (European Cup ↔ UEFA Champions League, UEFA Cup ↔ Europa League), treat as distinct and set defunct_year on the older slug.
+- Do NOT invent data. If uncertain on founded_year, return null rather than guess.`;
+
+async function extractBatch(
+  llm: LlmService,
+  batch: CanonicalEntity[]
+): Promise<GeminiBatchOutput> {
+  const items = batch
+    .map((e, i) => `[${i + 1}] id="${e.slug}" type="${e.type}" display_name="${e.display_name}"`)
+    .join('\n');
+  const userPrompt = `Return structured metadata for these ${batch.length} competitions:\n\n${items}\n\nReturn JSON exactly as specified.`;
+  return llm.generateStructuredJsonWithWebSearch<GeminiBatchOutput>(
+    SYSTEM_PROMPT,
+    userPrompt,
+    { maxRetries: 3 }
+  );
+}
+
+function validateRecord(
+  input: CanonicalEntity,
+  raw: GeminiBatchOutput['competitions'][number] | undefined
+): CompetitionMetadata {
+  const warnings: string[] = [];
+  if (!raw) {
+    warnings.push('Gemini returned no record for this slug');
+    return {
+      id: input.slug,
+      entity_type: input.type as 'league' | 'trophy',
+      display_name: input.display_name,
+      tier: null,
+      competition_type: null,
+      country_code: null,
+      founded_year: null,
+      defunct_year: null,
+      warnings,
+    };
+  }
+
+  let tier: number | null = null;
+  if (typeof raw.tier === 'number') {
+    const v = Math.round(raw.tier);
+    if (v >= 1 && v <= 5) tier = v;
+    else warnings.push(`tier out of range: ${raw.tier}`);
+  }
+
+  let competitionType: CompetitionType | null = null;
+  if (raw.competition_type) {
+    if ((ALLOWED_COMPETITION_TYPES as readonly string[]).includes(raw.competition_type)) {
+      competitionType = raw.competition_type as CompetitionType;
+    } else {
+      warnings.push(`invalid competition_type: ${raw.competition_type}`);
+    }
+  }
+
+  let countryCode: string | null = null;
+  if (raw.country_code && /^[a-z]{2}$/.test(raw.country_code)) {
+    countryCode = raw.country_code;
+  } else if (raw.country_code) {
+    warnings.push(`invalid country_code: ${raw.country_code}`);
+  }
+
+  const now = new Date().getUTCFullYear();
+  let foundedYear: number | null = null;
+  if (typeof raw.founded_year === 'number') {
+    const v = Math.round(raw.founded_year);
+    if (v >= 1850 && v <= now) foundedYear = v;
+    else warnings.push(`founded_year out of range: ${raw.founded_year}`);
+  }
+
+  let defunctYear: number | null = null;
+  if (typeof raw.defunct_year === 'number') {
+    const v = Math.round(raw.defunct_year);
+    if (v >= 1850 && v <= now) defunctYear = v;
+    else warnings.push(`defunct_year out of range: ${raw.defunct_year}`);
+  }
+
+  return {
+    id: input.slug,
+    entity_type: input.type as 'league' | 'trophy',
+    display_name: input.display_name,
+    tier,
+    competition_type: competitionType,
+    country_code: countryCode,
+    founded_year: foundedYear,
+    defunct_year: defunctYear,
+    warnings,
+  };
+}
+
+async function runBatched<T, R>(
+  items: T[],
+  batchSize: number,
+  concurrency: number,
+  fn: (batch: T[], idx: number) => Promise<R>
+): Promise<R[]> {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += batchSize) batches.push(items.slice(i, i + batchSize));
+  const results: R[] = new Array(batches.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(concurrency, batches.length) }, async () => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= batches.length) return;
+      try {
+        results[idx] = await fn(batches[idx], idx);
+        console.log(`  batch ${idx + 1}/${batches.length} done (${batches[idx].length} competitions)`);
+      } catch (err) {
+        console.error(`  batch ${idx + 1} failed:`, (err as Error).message);
+        results[idx] = undefined as unknown as R;
+      }
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+async function main(): Promise<void> {
+  const { batchSize, concurrency } = parseArgs();
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  const llm = app.get(LlmService);
+
+  const canonical = loadCanonicalEntities();
+  const competitions = canonical.all.filter(
+    (e) => e.type === 'league' || e.type === 'trophy'
+  );
+  console.log(
+    `Extracting metadata for ${competitions.length} competitions (${canonical.byType.get('league')?.length ?? 0} leagues + ${canonical.byType.get('trophy')?.length ?? 0} trophies).`
+  );
+
+  const batchResults = await runBatched(competitions, batchSize, concurrency, (batch) =>
+    extractBatch(llm, batch)
+  );
+
+  // Flatten all Gemini outputs into a single id -> raw record map.
+  const rawById = new Map<string, GeminiBatchOutput['competitions'][number]>();
+  for (const out of batchResults) {
+    if (!out) continue;
+    for (const c of out.competitions ?? []) {
+      if (c && typeof c.id === 'string') rawById.set(c.id, c);
+    }
+  }
+
+  // Merge each canonical competition with its Gemini record, preserving order.
+  const records = competitions.map((e) => validateRecord(e, rawById.get(e.slug)));
+
+  const warnCount = records.filter((r) => r.warnings.length > 0).length;
+  const summary = {
+    generated_at: new Date().toISOString(),
+    total: records.length,
+    warnings: warnCount,
+    counts_by_entity_type: {
+      league: records.filter((r) => r.entity_type === 'league').length,
+      trophy: records.filter((r) => r.entity_type === 'trophy').length,
+    },
+    counts_by_tier: [1, 2, 3, 4, 5].map((t) => ({
+      tier: t,
+      count: records.filter((r) => r.tier === t).length,
+    })),
+    records,
+  };
+  fs.writeFileSync(OUT_FILE, JSON.stringify(summary, null, 2), 'utf8');
+
+  console.log(`\nWritten: ${OUT_FILE}`);
+  console.log(`  ${records.length} competitions · ${warnCount} with warnings`);
+  console.log('\nReview the JSON, fix any wrong tiers/types, then seed competition_metadata from it.');
+
+  await app.close();
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/backend/scripts/review-canonical-entities.ts
+++ b/backend/scripts/review-canonical-entities.ts
@@ -1,0 +1,505 @@
+#!/usr/bin/env npx ts-node
+/* eslint-disable no-undef, no-console */
+/**
+ * Interactive review UI for the canonical entity list.
+ *
+ * Flags:
+ *   1. Invalid types (not in allowed enum) — default to DELETE
+ *   2. Likely duplicate pairs — choose keep-A / keep-B / keep-both
+ *   3. Top-N per type — read-only sanity scan
+ *
+ * You make choices in the browser. State persists in localStorage so you can
+ * stop and come back. When done, click "Download cleaned JSON" and save it
+ * as canonical-entities.cleaned.json next to the source file.
+ *
+ * Run:  npm run pool:review-entities
+ * Open: backend/scripts/_backfill-pool/canonical-entities.review.html
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ALLOWED_TYPES = ['player', 'team', 'league', 'trophy', 'manager', 'stadium', 'country'] as const;
+type AllowedType = (typeof ALLOWED_TYPES)[number];
+
+const IN_FILE = path.resolve(__dirname, '_backfill-pool', 'canonical-entities.json');
+const OUT_FILE = path.resolve(__dirname, '_backfill-pool', 'canonical-entities.review.html');
+
+interface Entity {
+  type: string;
+  slug: string;
+  display_name: string;
+  aliases: string[];
+  mention_count: number;
+  sample_question_ids: string[];
+}
+
+interface Source {
+  generated_at: string;
+  source: Record<string, unknown>;
+  counts_by_type: Record<string, number>;
+  entities: Entity[];
+}
+
+interface DupePair {
+  a_id: number;
+  b_id: number;
+  reason: string;
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  const m = a.length, n = b.length;
+  if (!m || !n) return m || n;
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  let curr = new Array<number>(n + 1).fill(0);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n];
+}
+
+function normalise(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function findDupes(entities: Entity[]): DupePair[] {
+  const byType = new Map<string, Array<{ idx: number; e: Entity }>>();
+  entities.forEach((e, idx) => {
+    if (!byType.has(e.type)) byType.set(e.type, []);
+    byType.get(e.type)!.push({ idx, e });
+  });
+
+  const pairs: DupePair[] = [];
+  for (const [, list] of byType) {
+    for (let i = 0; i < list.length; i++) {
+      for (let j = i + 1; j < list.length; j++) {
+        const A = list[i], B = list[j];
+        const an = normalise(A.e.display_name), bn = normalise(B.e.display_name);
+
+        if (an === bn) {
+          pairs.push({ a_id: A.idx, b_id: B.idx, reason: 'same normalised display_name' });
+          continue;
+        }
+
+        const dist = levenshtein(A.e.slug, B.e.slug);
+        const maxLen = Math.max(A.e.slug.length, B.e.slug.length);
+        if (dist > 0 && dist <= 2 && maxLen >= 6) {
+          pairs.push({ a_id: A.idx, b_id: B.idx, reason: `slug Levenshtein=${dist}` });
+          continue;
+        }
+
+        const aNames = [A.e.display_name, ...A.e.aliases].map(normalise);
+        const bNames = [B.e.display_name, ...B.e.aliases].map(normalise);
+        const overlap = aNames.filter((n) => bNames.includes(n));
+        if (overlap.length > 0) {
+          pairs.push({ a_id: A.idx, b_id: B.idx, reason: `shared alias "${overlap[0]}"` });
+        }
+      }
+    }
+  }
+  return pairs;
+}
+
+function renderHtml(src: Source, dupes: DupePair[], invalidIds: number[], topByType: Map<string, Entity[]>): string {
+  const payload = {
+    generated_at: src.generated_at,
+    counts_by_type: src.counts_by_type,
+    entities: src.entities,
+    dupes,
+    invalid_ids: invalidIds,
+    allowed_types: ALLOWED_TYPES as unknown as string[],
+    storage_key: 'canonical-entities-review-v1',
+  };
+
+  const topByTypeMap: Record<string, number[]> = {};
+  for (const [t, list] of topByType) {
+    topByTypeMap[t] = list.map((e) => src.entities.indexOf(e));
+  }
+  (payload as Record<string, unknown>).top_by_type = topByTypeMap;
+
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Canonical entities — review</title>
+<style>
+  :root { --bg:#fafafa; --card:#fff; --line:#e5e7eb; --muted:#6b7280; --accent:#2563eb; --warn:#f59e0b; --danger:#dc2626; --ok:#059669; }
+  * { box-sizing: border-box; }
+  body { font: 14px/1.5 -apple-system, system-ui, sans-serif; margin: 0; color: #111; background: var(--bg); }
+  header { position: sticky; top: 0; z-index: 10; background: #fff; border-bottom: 1px solid var(--line); padding: .75rem 1.25rem; display: flex; align-items: center; gap: 1rem; }
+  header h1 { font-size: 1rem; margin: 0; flex: 1; }
+  header button { font: inherit; padding: .4rem .8rem; border: 1px solid var(--line); background: #fff; border-radius: 6px; cursor: pointer; }
+  header button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+  header button.primary:hover { background: #1d4ed8; }
+  header button:hover { background: #f3f4f6; }
+  main { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 6rem; }
+  h2 { margin-top: 2.5rem; padding-bottom: .4rem; border-bottom: 1px solid var(--line); font-size: 1.1rem; }
+  h3 { margin-top: 1.5rem; font-size: .95rem; }
+  .summary { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 1rem 1.25rem; }
+  .summary ul { margin: .4rem 0 0 0; padding-left: 1.25rem; }
+  .dim { color: var(--muted); font-weight: normal; }
+  .pair { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: .85rem 1rem; margin-bottom: .6rem; }
+  .pair.resolved { opacity: .55; }
+  .pair-head { display: flex; justify-content: space-between; align-items: center; font-size: .75rem; text-transform: uppercase; color: var(--warn); letter-spacing: .5px; margin-bottom: .5rem; }
+  .pair-head .status { color: var(--muted); }
+  .pair-body { display: grid; grid-template-columns: 1fr 1fr; gap: .6rem; }
+  .choice { border: 2px solid var(--line); border-radius: 6px; padding: .55rem .75rem; cursor: pointer; transition: background .1s, border-color .1s; position: relative; }
+  .choice:hover { background: #f9fafb; }
+  .choice.sel { border-color: var(--accent); background: #eff6ff; }
+  .choice .slug { font-family: ui-monospace, Menlo, monospace; font-size: .82em; background: #f1f5f9; padding: 1px 6px; border-radius: 3px; display: inline-block; }
+  .choice .name { font-weight: 600; margin-top: .25rem; }
+  .choice .meta { color: var(--muted); font-size: .8em; margin-top: .15rem; }
+  .choice .aliases { color: #94a3b8; font-size: .78em; font-style: italic; margin-top: .2rem; }
+  .pair-actions { display: flex; gap: .5rem; margin-top: .55rem; }
+  .pair-actions button { font: inherit; border: 1px solid var(--line); background: #fff; padding: .25rem .6rem; border-radius: 4px; cursor: pointer; font-size: .85em; }
+  .pair-actions button.sel { border-color: var(--accent); color: var(--accent); background: #eff6ff; font-weight: 600; }
+  table.top { width: 100%; border-collapse: collapse; margin-top: .5rem; background: var(--card); border: 1px solid var(--line); border-radius: 6px; overflow: hidden; }
+  table.top th, table.top td { padding: .35rem .75rem; border-bottom: 1px solid var(--line); text-align: left; }
+  table.top th { background: #f3f4f6; font-weight: 600; font-size: .85em; }
+  td.n { text-align: right; font-variant-numeric: tabular-nums; color: #475569; width: 80px; }
+  code { font-family: ui-monospace, Menlo, monospace; background: #f1f5f9; padding: 1px 6px; border-radius: 3px; font-size: .88em; }
+  .invalid-row label { display: flex; align-items: center; gap: .6rem; padding: .5rem .75rem; background: var(--card); border: 1px solid var(--line); border-radius: 6px; cursor: pointer; margin-bottom: .3rem; }
+  .invalid-row label.kept { border-color: var(--ok); background: #ecfdf5; }
+  .invalid-row input { margin: 0; }
+  .invalid-row select { font: inherit; padding: .2rem .4rem; }
+  .filter-bar { margin: 1rem 0 .5rem; }
+  .filter-bar button { font: inherit; padding: .25rem .6rem; border: 1px solid var(--line); background: #fff; border-radius: 4px; cursor: pointer; font-size: .85em; margin-right: .3rem; }
+  .filter-bar button.active { background: #111; color: #fff; border-color: #111; }
+  footer-bar { position: fixed; bottom: 1rem; right: 1rem; background: var(--accent); color: #fff; padding: .6rem 1rem; border-radius: 6px; font-weight: 600; box-shadow: 0 4px 12px rgba(0,0,0,.15); }
+</style></head>
+<body>
+<header>
+  <h1>Canonical entities — review</h1>
+  <span id="progress" class="dim">0/0 resolved</span>
+  <button onclick="resetAll()">Reset</button>
+  <button class="primary" onclick="downloadCleaned()">Download cleaned JSON</button>
+</header>
+
+<main>
+  <div class="summary" id="summary"></div>
+
+  <h2>1. Invalid types <span class="dim">(must remove — or reassign to a valid type)</span></h2>
+  <div id="invalid-section"></div>
+
+  <h2>2. Duplicate pairs <span class="dim">(pick which to keep; loser's aliases + mention_count merge into winner)</span></h2>
+  <div class="filter-bar">
+    <strong>Filter:</strong>
+    <button data-filter="all" class="active">All</button>
+    <button data-filter="unresolved">Unresolved only</button>
+    <button data-filter="resolved">Resolved only</button>
+  </div>
+  <div id="dupes-section"></div>
+
+  <h2>3. Top 30 per type <span class="dim">(read-only sanity scan)</span></h2>
+  <div id="top-section"></div>
+</main>
+
+<script id="payload" type="application/json">${JSON.stringify(payload)}</script>
+<script>
+(function () {
+  const DATA = JSON.parse(document.getElementById('payload').textContent);
+  const STORAGE = DATA.storage_key;
+  const ENTITIES = DATA.entities;
+
+  // State shape:
+  //   dupes: { "<pair_index>": "a" | "b" | "both" }
+  //   invalid: { "<entity_index>": "delete" | "<valid_type>" }
+  const saved = loadState();
+  const state = {
+    dupes: saved.dupes || {},
+    invalid: saved.invalid || {},
+    filter: 'all',
+  };
+
+  function loadState() {
+    try { return JSON.parse(localStorage.getItem(STORAGE) || '{}'); }
+    catch { return {}; }
+  }
+  function saveState() {
+    localStorage.setItem(STORAGE, JSON.stringify({ dupes: state.dupes, invalid: state.invalid }));
+    updateProgress();
+  }
+
+  function esc(s) { return String(s).replace(/[&<>"]/g, (c) => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[c])); }
+  function renderEntity(e) {
+    const aliases = e.aliases.length ? '<div class="aliases">aka: ' + esc(e.aliases.join(', ')) + '</div>' : '';
+    return '<span class="slug">' + esc(e.slug) + '</span>' +
+           '<div class="name">' + esc(e.display_name) + '</div>' +
+           '<div class="meta">' + e.mention_count + ' mention' + (e.mention_count === 1 ? '' : 's') + ' · ' + esc(e.type) + '</div>' +
+           aliases;
+  }
+
+  function renderSummary() {
+    const total = ENTITIES.length;
+    const dupes = DATA.dupes.length;
+    const invalid = DATA.invalid_ids.length;
+    const byType = DATA.counts_by_type;
+    const typeRows = Object.entries(byType).sort().map(([t, c]) => {
+      const bad = DATA.allowed_types.includes(t) ? '' : ' <strong style="color:var(--danger)">(invalid)</strong>';
+      return '<li><code>' + esc(t) + '</code> — ' + c + bad + '</li>';
+    }).join('');
+    document.getElementById('summary').innerHTML =
+      '<div><strong>Generated:</strong> ' + esc(DATA.generated_at) + '</div>' +
+      '<div><strong>Total entities:</strong> ' + total + '</div>' +
+      '<div><strong>Flags:</strong> ' + invalid + ' invalid · ' + dupes + ' dupe pairs</div>' +
+      '<div><strong>By type:</strong><ul>' + typeRows + '</ul></div>';
+  }
+
+  function renderInvalid() {
+    const container = document.getElementById('invalid-section');
+    if (DATA.invalid_ids.length === 0) {
+      container.innerHTML = '<p style="color:var(--ok)">No invalid types.</p>';
+      return;
+    }
+    container.innerHTML = DATA.invalid_ids.map((id) => {
+      const e = ENTITIES[id];
+      const choice = state.invalid[id] || 'delete';
+      const typeOptions = DATA.allowed_types.map((t) => '<option value="' + t + '"' + (choice === t ? ' selected' : '') + '>' + t + '</option>').join('');
+      return '<div class="invalid-row"><label class="' + (choice !== 'delete' ? 'kept' : '') + '">' +
+        '<input type="checkbox" data-id="' + id + '" ' + (choice !== 'delete' ? 'checked' : '') + '>' +
+        '<span style="flex:1"><code>' + esc(e.type) + '</code> → <code>' + esc(e.slug) + '</code> · ' + esc(e.display_name) + ' (' + e.mention_count + ' mentions)</span>' +
+        '<span class="dim">keep as:</span> <select data-id="' + id + '" ' + (choice === 'delete' ? 'disabled' : '') + '>' + typeOptions + '</select>' +
+        '</label></div>';
+    }).join('');
+    container.querySelectorAll('input[type=checkbox]').forEach((cb) => {
+      cb.addEventListener('change', (ev) => {
+        const id = ev.target.dataset.id;
+        const sel = container.querySelector('select[data-id="' + id + '"]');
+        if (ev.target.checked) {
+          state.invalid[id] = sel.value;
+          sel.disabled = false;
+        } else {
+          state.invalid[id] = 'delete';
+          sel.disabled = true;
+        }
+        saveState(); renderInvalid();
+      });
+    });
+    container.querySelectorAll('select').forEach((sel) => {
+      sel.addEventListener('change', (ev) => {
+        const id = ev.target.dataset.id;
+        state.invalid[id] = ev.target.value;
+        saveState(); renderInvalid();
+      });
+    });
+  }
+
+  function renderDupes() {
+    const container = document.getElementById('dupes-section');
+    if (DATA.dupes.length === 0) {
+      container.innerHTML = '<p style="color:var(--ok)">No duplicates detected.</p>';
+      return;
+    }
+    const html = DATA.dupes.map((p, idx) => {
+      const a = ENTITIES[p.a_id], b = ENTITIES[p.b_id];
+      const choice = state.dupes[idx];
+      const resolved = !!choice;
+      if (state.filter === 'unresolved' && resolved) return '';
+      if (state.filter === 'resolved' && !resolved) return '';
+      const status = choice ? 'resolved — ' + (choice === 'both' ? 'kept both' : 'keep ' + choice.toUpperCase()) : 'unresolved';
+      return '<div class="pair ' + (resolved ? 'resolved' : '') + '" data-idx="' + idx + '">' +
+        '<div class="pair-head"><span>' + esc(p.reason) + '</span><span class="status">' + status + '</span></div>' +
+        '<div class="pair-body">' +
+          '<div class="choice ' + (choice === 'a' ? 'sel' : '') + '" data-pick="a">' + renderEntity(a) + '</div>' +
+          '<div class="choice ' + (choice === 'b' ? 'sel' : '') + '" data-pick="b">' + renderEntity(b) + '</div>' +
+        '</div>' +
+        '<div class="pair-actions">' +
+          '<button data-pick="a" class="' + (choice === 'a' ? 'sel' : '') + '">Keep A</button>' +
+          '<button data-pick="b" class="' + (choice === 'b' ? 'sel' : '') + '">Keep B</button>' +
+          '<button data-pick="both" class="' + (choice === 'both' ? 'sel' : '') + '">Keep both (not a dupe)</button>' +
+          '<button data-pick="clear">Clear</button>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+    container.innerHTML = html;
+
+    container.querySelectorAll('.pair').forEach((el) => {
+      const idx = el.dataset.idx;
+      el.querySelectorAll('[data-pick]').forEach((btn) => {
+        btn.addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          const pick = btn.dataset.pick;
+          if (pick === 'clear') delete state.dupes[idx];
+          else state.dupes[idx] = pick;
+          saveState(); renderDupes();
+        });
+      });
+    });
+  }
+
+  function renderTop() {
+    const c = document.getElementById('top-section');
+    const types = Object.keys(DATA.top_by_type).sort();
+    c.innerHTML = types.map((t) => {
+      const ids = DATA.top_by_type[t];
+      const rows = ids.map((id) => {
+        const e = ENTITIES[id];
+        return '<tr><td class="n">' + e.mention_count + '</td><td><code>' + esc(e.slug) + '</code></td><td>' + esc(e.display_name) + '</td><td class="dim">' + esc(e.aliases.join(', ')) + '</td></tr>';
+      }).join('');
+      return '<h3>' + esc(t) + ' <span class="dim">(' + (DATA.counts_by_type[t] || 0) + ' total)</span></h3>' +
+        '<table class="top"><thead><tr><th>Mentions</th><th>Slug</th><th>Display name</th><th>Aliases</th></tr></thead><tbody>' + rows + '</tbody></table>';
+    }).join('');
+  }
+
+  function updateProgress() {
+    const invalidResolved = DATA.invalid_ids.length;
+    const dupesResolved = Object.keys(state.dupes).length;
+    const total = DATA.invalid_ids.length + DATA.dupes.length;
+    const resolved = invalidResolved + dupesResolved;
+    document.getElementById('progress').textContent = resolved + '/' + total + ' resolved';
+  }
+
+  document.querySelectorAll('.filter-bar button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.filter-bar button').forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+      state.filter = btn.dataset.filter;
+      renderDupes();
+    });
+  });
+
+  window.resetAll = function () {
+    if (!confirm('Reset all choices?')) return;
+    state.dupes = {}; state.invalid = {};
+    localStorage.removeItem(STORAGE);
+    renderInvalid(); renderDupes(); updateProgress();
+  };
+
+  window.downloadCleaned = function () {
+    // Build cleaned entity list.
+    // 1. Reassign invalid types (or drop).
+    // 2. Merge dupes: winner inherits loser's aliases + mention_count + sample_question_ids.
+    const dropIds = new Set();
+    const typeOverrides = {};
+    DATA.invalid_ids.forEach((id) => {
+      const choice = state.invalid[id] || 'delete';
+      if (choice === 'delete') dropIds.add(id);
+      else typeOverrides[id] = choice;
+    });
+
+    const mergeInto = {}; // loser_id -> winner_id
+    DATA.dupes.forEach((p, idx) => {
+      const c = state.dupes[idx];
+      if (c === 'a') mergeInto[p.b_id] = p.a_id;
+      else if (c === 'b') mergeInto[p.a_id] = p.b_id;
+      // 'both' or undefined -> skip
+    });
+
+    // Resolve transitive merges (a→b, b→c ⇒ a→c)
+    for (const loser in mergeInto) {
+      let target = mergeInto[loser];
+      const seen = new Set([Number(loser)]);
+      while (mergeInto[target] !== undefined && !seen.has(target)) {
+        seen.add(target);
+        target = mergeInto[target];
+      }
+      mergeInto[loser] = target;
+    }
+
+    const cleaned = [];
+    const winnerMap = new Map(); // winner_id -> new entity
+    ENTITIES.forEach((e, id) => {
+      if (dropIds.has(id)) return;
+      if (mergeInto[id] !== undefined) return; // handled as loser below
+      const newE = { ...e, aliases: [...e.aliases], sample_question_ids: [...e.sample_question_ids] };
+      if (typeOverrides[id]) newE.type = typeOverrides[id];
+      cleaned.push(newE);
+      winnerMap.set(id, newE);
+    });
+    // Apply merges.
+    ENTITIES.forEach((e, id) => {
+      if (mergeInto[id] === undefined) return;
+      const winner = winnerMap.get(mergeInto[id]);
+      if (!winner) return;
+      winner.mention_count += e.mention_count;
+      // Add loser's display_name + aliases to winner's aliases.
+      const existing = new Set([winner.display_name, ...winner.aliases]);
+      if (!existing.has(e.display_name)) winner.aliases.push(e.display_name);
+      e.aliases.forEach((a) => { if (!existing.has(a)) winner.aliases.push(a); });
+      // Union sample IDs up to 5.
+      const sampleSet = new Set(winner.sample_question_ids);
+      e.sample_question_ids.forEach((sid) => { if (sampleSet.size < 5) sampleSet.add(sid); });
+      winner.sample_question_ids = Array.from(sampleSet);
+    });
+
+    cleaned.sort((a, b) => b.mention_count - a.mention_count);
+    const countsByType = {};
+    cleaned.forEach((e) => { countsByType[e.type] = (countsByType[e.type] || 0) + 1; });
+
+    const out = {
+      generated_at: DATA.generated_at,
+      reviewed_at: new Date().toISOString(),
+      source: { cleaned_from: 'canonical-entities.json', decisions: { dupes_resolved: Object.keys(state.dupes).length, invalid_handled: DATA.invalid_ids.length } },
+      counts_by_type: countsByType,
+      entities: cleaned,
+    };
+
+    const blob = new Blob([JSON.stringify(out, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'canonical-entities.cleaned.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  renderSummary(); renderInvalid(); renderDupes(); renderTop(); updateProgress();
+})();
+</script>
+</body></html>`;
+}
+
+function main(): void {
+  if (!fs.existsSync(IN_FILE)) {
+    console.error('Missing ' + IN_FILE + '. Run pool:extract-entities first.');
+    process.exit(1);
+  }
+  const src = JSON.parse(fs.readFileSync(IN_FILE, 'utf8')) as Source;
+
+  const invalidIds = src.entities
+    .map((e, i) => (ALLOWED_TYPES.includes(e.type as AllowedType) ? -1 : i))
+    .filter((i) => i >= 0);
+
+  const validEntities = src.entities.filter((e) => ALLOWED_TYPES.includes(e.type as AllowedType));
+  const dupesOnValid = findDupes(validEntities);
+
+  // Remap dupe indices (which are relative to validEntities) back to full ENTITIES array.
+  const validIdxToFullIdx: number[] = [];
+  src.entities.forEach((e, i) => {
+    if (ALLOWED_TYPES.includes(e.type as AllowedType)) validIdxToFullIdx.push(i);
+  });
+  const dupes: DupePair[] = dupesOnValid.map((p) => ({
+    a_id: validIdxToFullIdx[p.a_id],
+    b_id: validIdxToFullIdx[p.b_id],
+    reason: p.reason,
+  }));
+
+  const topByType = new Map<string, Entity[]>();
+  for (const e of validEntities) {
+    if (!topByType.has(e.type)) topByType.set(e.type, []);
+    topByType.get(e.type)!.push(e);
+  }
+  for (const [t, list] of topByType) {
+    topByType.set(t, list.sort((a, b) => b.mention_count - a.mention_count).slice(0, 30));
+  }
+
+  const html = renderHtml(src, dupes, invalidIds, topByType);
+  fs.writeFileSync(OUT_FILE, html, 'utf8');
+
+  console.log('Interactive review report written to:\n  ' + OUT_FILE);
+  console.log('\nSummary:');
+  console.log('  invalid-type rows : ' + invalidIds.length);
+  console.log('  likely dupe pairs : ' + dupes.length);
+  console.log('  total entities    : ' + src.entities.length);
+  console.log('\nOpen the HTML, make your choices (saved in localStorage as you go),');
+  console.log('then click "Download cleaned JSON" at the top. Save it next to the source.');
+}
+
+main();

--- a/backend/scripts/seed-competition-metadata.ts
+++ b/backend/scripts/seed-competition-metadata.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env npx ts-node
+/* eslint-disable no-undef, no-console */
+/**
+ * Seed competition_metadata from the reviewed competition-metadata.json.
+ * Idempotent — uses INSERT ... ON CONFLICT DO UPDATE so re-runs are safe
+ * and propagate any manual edits.
+ *
+ * The 7 individual awards (ballon-dor, golden-boot, etc.) are included with
+ * entity_type='award' so they remain discoverable for future award-themed
+ * modes, but tier is left NULL so they don't pollute tier analytics.
+ *
+ * Run: npm run pool:seed-competitions
+ */
+import { NestFactory } from '@nestjs/core';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AppModule } from '../src/app.module';
+import { SupabaseService } from '../src/supabase/supabase.service';
+
+const IN_FILE = path.resolve(
+  __dirname,
+  '_backfill-pool',
+  'competition-metadata.json'
+);
+
+// Individual-award slugs: reclassify entity_type from "trophy" → "award" on seed
+// so downstream queries can filter them out of tier-based analytics cleanly.
+const AWARD_SLUGS = new Set([
+  'ballon-dor',
+  'premier-league-golden-boot',
+  'european-golden-shoe',
+  'european-golden-boot',
+  'pichichi-trophy',
+  'torjagerkanone',
+  'capocannoniere',
+]);
+
+interface InputRecord {
+  id: string;
+  entity_type: 'league' | 'trophy';
+  display_name: string;
+  tier: number | null;
+  competition_type: string | null;
+  country_code: string | null;
+  founded_year: number | null;
+  defunct_year: number | null;
+  warnings?: string[];
+}
+
+interface Input {
+  records: InputRecord[];
+}
+
+async function main(): Promise<void> {
+  if (!fs.existsSync(IN_FILE)) {
+    console.error(`Missing ${IN_FILE}. Run pool:extract-competitions first.`);
+    process.exit(1);
+  }
+  const src = JSON.parse(fs.readFileSync(IN_FILE, 'utf8')) as Input;
+
+  // Dedupe by id. When the same slug appears as both "league" and "trophy"
+  // (e.g. premier-league is extracted as both — the league IS the trophy),
+  // prefer the "league" record because the league semantics are stronger.
+  const TYPE_PREFERENCE = { league: 0, trophy: 1, award: 2 } as const;
+  const byId = new Map<string, InputRecord>();
+  let dropped = 0;
+  for (const r of src.records) {
+    const existing = byId.get(r.id);
+    if (!existing) {
+      byId.set(r.id, r);
+      continue;
+    }
+    const keepExisting =
+      TYPE_PREFERENCE[existing.entity_type] <= TYPE_PREFERENCE[r.entity_type];
+    if (!keepExisting) byId.set(r.id, r);
+    dropped++;
+    console.log(
+      `  dedupe: id="${r.id}" — kept ${keepExisting ? existing.entity_type : r.entity_type}, dropped ${keepExisting ? r.entity_type : existing.entity_type}`,
+    );
+  }
+
+  const rows = Array.from(byId.values()).map((r) => ({
+    id: r.id,
+    entity_type: AWARD_SLUGS.has(r.id) ? 'award' : r.entity_type,
+    display_name: r.display_name,
+    tier: AWARD_SLUGS.has(r.id) ? null : r.tier,
+    competition_type: r.competition_type,
+    country_code: r.country_code,
+    founded_year: r.founded_year,
+    defunct_year: r.defunct_year,
+  }));
+  if (dropped > 0) console.log(`  (${dropped} duplicates collapsed)\n`);
+
+  console.log(`Seeding ${rows.length} competitions (leagues + trophies + awards)...`);
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  const supabase = app.get(SupabaseService);
+
+  const { error } = await supabase.client
+    .from('competition_metadata')
+    .upsert(rows, { onConflict: 'id' });
+
+  if (error) {
+    console.error('Seed failed:', error.message);
+    process.exit(1);
+  }
+
+  // Verify counts.
+  const { count } = await supabase.client
+    .from('competition_metadata')
+    .select('id', { count: 'exact', head: true });
+
+  console.log(`Done. competition_metadata now has ${count ?? '?'} rows.`);
+  console.log('\nNext: trigger will auto-populate question_pool.league_tier + competition_type');
+  console.log('for any new INSERT or UPDATE that touches competition_id. Existing rows stay unchanged');
+  console.log('(already backfilled by the classifier pass).');
+
+  await app.close();
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/backend/scripts/seed-logo-questions.ts
+++ b/backend/scripts/seed-logo-questions.ts
@@ -136,6 +136,23 @@ async function main() {
   }
 
   console.log(`  Done: ${inserted} questions seeded`);
+
+  // Invalidate the logo-quiz team-names cache so newly-seeded logos show up
+  // in the select immediately instead of waiting out the 1h TTL.
+  if (inserted > 0) {
+    try {
+      const { Redis } = await import('ioredis');
+      const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
+      const redis = new Redis(url, { maxRetriesPerRequest: null });
+      await redis.del('logo:team_names');
+      await redis.quit();
+      console.log('  Invalidated logo:team_names cache');
+    } catch (err) {
+      console.warn(
+        `  WARN: cache invalidation failed (users may see stale select for up to 1h): ${(err as Error).message}`,
+      );
+    }
+  }
 }
 
 main().catch((e) => {

--- a/backend/src/logo-quiz/logo-quiz.service.ts
+++ b/backend/src/logo-quiz/logo-quiz.service.ts
@@ -266,6 +266,15 @@ export class LogoQuizService {
   }
 
   /**
+   * Purge the cached team-name list. Call after seeding new LOGO_QUIZ rows so
+   * the next `getTeamNames()` call rebuilds the list from question_pool.
+   * Without this, newly-seeded logos stay hidden from the select for up to 1h.
+   */
+  async invalidateTeamNamesCache(): Promise<void> {
+    await this.cacheService.del(LogoQuizService.TEAM_NAMES_CACHE_KEY);
+  }
+
+  /**
    * Draw `count` unique random logo questions for team/battle-royale modes.
    * Returns the question's image_url for gameplay and the original for reveal.
    */

--- a/backend/src/questions/classifiers/canonical-entities.cleaned.json
+++ b/backend/src/questions/classifiers/canonical-entities.cleaned.json
@@ -1,0 +1,12538 @@
+{
+  "generated_at": "2026-04-15T22:27:00.809Z",
+  "reviewed_at": "2026-04-15T22:43:22.627Z",
+  "source": {
+    "cleaned_from": "canonical-entities.json",
+    "decisions": {
+      "dupes_resolved": 69,
+      "invalid_handled": 1
+    }
+  },
+  "counts_by_type": {
+    "trophy": 59,
+    "league": 28,
+    "team": 327,
+    "country": 56,
+    "player": 448,
+    "manager": 71,
+    "stadium": 133
+  },
+  "entities": [
+    {
+      "type": "trophy",
+      "slug": "uefa-champions-league",
+      "display_name": "UEFA Champions League",
+      "aliases": [
+        "Champions League"
+      ],
+      "mention_count": 135,
+      "sample_question_ids": [
+        "9783dd22-6b15-4f30-bad8-b94af4d5101b",
+        "2a929c0d-baeb-40aa-a93d-bc23780bb019",
+        "6eb2f422-406c-4926-9c5d-a605c39094ac",
+        "f4fb5b28-0dfa-477d-849f-2ca1a5b6922a",
+        "b99c5d8a-85bc-4c23-a586-7e4ad54f9173"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "fifa-world-cup",
+      "display_name": "FIFA World Cup",
+      "aliases": [
+        "World Cup"
+      ],
+      "mention_count": 123,
+      "sample_question_ids": [
+        "8076c232-b9b0-4cb7-b65c-bb012ce89cf5",
+        "e9f00fc1-748e-459e-91f8-49014245965c",
+        "397dc9a4-b161-47f7-b0ac-9ce5daf1f432",
+        "7f9bc667-a36d-4b96-b715-8c885bf30a2b",
+        "c43bbec4-e7e3-4d70-90ac-b466ea2b6584"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "premier-league",
+      "display_name": "Premier League",
+      "aliases": [],
+      "mention_count": 98,
+      "sample_question_ids": [
+        "d744b3d2-1cc7-43b3-9869-7aa77b1da74d",
+        "4c9120ee-de05-495a-bc19-fa3f84433345",
+        "83e5dbad-b036-4fac-bfc3-57642f330171",
+        "305af037-445a-4175-8544-587a3170a840",
+        "fb882f56-7414-44c9-b9d3-e9963bde62db"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "manchester-united",
+      "display_name": "Manchester United",
+      "aliases": [
+        "United"
+      ],
+      "mention_count": 64,
+      "sample_question_ids": [
+        "2ca872a2-d486-44da-9c53-0495aaa53f48",
+        "83e5dbad-b036-4fac-bfc3-57642f330171",
+        "d426bb98-5e9e-494a-b5ce-83417523420f",
+        "0dfb6ff3-d1de-4033-916e-1a362652cb83",
+        "cfec34dc-5f17-4f0a-850b-c5a0d23e698b"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bayern-munich",
+      "display_name": "Bayern Munich",
+      "aliases": [],
+      "mention_count": 61,
+      "sample_question_ids": [
+        "e9ca6402-d177-4902-aff9-2a27dd2485a8",
+        "305af037-445a-4175-8544-587a3170a840",
+        "474c5d85-389e-40cd-a3cb-199fb3355565",
+        "10f22af6-d66c-4e97-9abd-933edf6d8791",
+        "b587ea87-5801-43fa-ba8e-26f0939f954b"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-barcelona",
+      "display_name": "FC Barcelona",
+      "aliases": [
+        "Barcelona",
+        "Barcelona 'Dream Team'"
+      ],
+      "mention_count": 60,
+      "sample_question_ids": [
+        "fb3711a2-1dde-43d1-a9fe-423b83f1903f",
+        "a140ee10-bdc4-42a2-8e9c-388b30563854",
+        "2a929c0d-baeb-40aa-a93d-bc23780bb019",
+        "cfa96cb2-0fd2-42ee-9d71-e482fe9a37f8",
+        "d1b12993-7530-4f83-b8c9-c94b3d0d96aa"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "liverpool",
+      "display_name": "Liverpool FC",
+      "aliases": [],
+      "mention_count": 59,
+      "sample_question_ids": [
+        "fb3711a2-1dde-43d1-a9fe-423b83f1903f",
+        "d1b12993-7530-4f83-b8c9-c94b3d0d96aa",
+        "b99c5d8a-85bc-4c23-a586-7e4ad54f9173",
+        "7d9773bf-9bfc-4520-ba6a-f324ab7b6bd9",
+        "69cbfcfc-a205-4d40-8f78-60b3179ac81d"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "european-cup",
+      "display_name": "European Cup",
+      "aliases": [],
+      "mention_count": 58,
+      "sample_question_ids": [
+        "31bbea25-dbc6-45a0-80f7-6c47868fb682",
+        "a140ee10-bdc4-42a2-8e9c-388b30563854",
+        "5a1ad6b9-962f-455b-8c89-eb776d5b7186",
+        "e9ca6402-d177-4902-aff9-2a27dd2485a8",
+        "a581005f-8459-4d4d-8e19-6e079e6edc06"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "real-madrid",
+      "display_name": "Real Madrid",
+      "aliases": [
+        "Los Blancos"
+      ],
+      "mention_count": 51,
+      "sample_question_ids": [
+        "fb3711a2-1dde-43d1-a9fe-423b83f1903f",
+        "b99c5d8a-85bc-4c23-a586-7e4ad54f9173",
+        "7d9773bf-9bfc-4520-ba6a-f324ab7b6bd9",
+        "b08f7569-13e5-4bf1-a92d-519285814af6",
+        "cb1ab2a6-fd19-4ac9-a367-2944babb6163"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "chelsea",
+      "display_name": "Chelsea",
+      "aliases": [
+        "Chelsea FC"
+      ],
+      "mention_count": 49,
+      "sample_question_ids": [
+        "d1b12993-7530-4f83-b8c9-c94b3d0d96aa",
+        "305af037-445a-4175-8544-587a3170a840",
+        "200e98f8-5ae5-4391-a06c-20b212e5800f",
+        "88567b0f-3942-4c2e-bc13-d3bafbe9408f",
+        "4447e6cb-3434-43a4-bcd5-7b24df278b97"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "serie-a",
+      "display_name": "Serie A",
+      "aliases": [
+        "First Division"
+      ],
+      "mention_count": 45,
+      "sample_question_ids": [
+        "eae44df1-2661-4fb1-921b-8028c317e9fa",
+        "94d4c673-224b-48d6-b831-9f37bf84d160",
+        "45ec50c2-f636-47fa-b85a-a95d0a6ad784",
+        "86c14847-1e8f-466a-93ed-719f5b0f02b4",
+        "3b498b3f-8dee-42cc-8c39-86b072eafa41"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-european-championship",
+      "display_name": "UEFA European Championship",
+      "aliases": [
+        "Euro 1992",
+        "Euro",
+        "Euro 2004",
+        "UEFA Euro",
+        "Euro 2008",
+        "UEFA Euro 1992"
+      ],
+      "mention_count": 44,
+      "sample_question_ids": [
+        "6f27bca6-2d37-425a-b872-d90225dca944",
+        "9e149d3b-3c80-4280-b8ed-6b1da0288a30",
+        "539daa85-7bff-4788-bf88-ce21e42d7868",
+        "fe6fb11e-7d1b-4646-89ec-40d433aa27db",
+        "e1cc887e-f59d-47e8-ae1e-34f440e868fb"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ac-milan",
+      "display_name": "AC Milan",
+      "aliases": [
+        "Milan"
+      ],
+      "mention_count": 41,
+      "sample_question_ids": [
+        "fb3711a2-1dde-43d1-a9fe-423b83f1903f",
+        "94d4c673-224b-48d6-b831-9f37bf84d160",
+        "a71e279d-4bfd-460a-91cf-e4071e3061e3",
+        "c2d95ab7-57fb-4829-bf36-8ee5fdbe6d41",
+        "38ba72bc-06bc-4113-a4dc-a993f4f9d751"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "juventus",
+      "display_name": "Juventus",
+      "aliases": [
+        "Juventus FC"
+      ],
+      "mention_count": 38,
+      "sample_question_ids": [
+        "eae44df1-2661-4fb1-921b-8028c317e9fa",
+        "086e9f68-c7dc-4981-be54-24264b609794",
+        "a581005f-8459-4d4d-8e19-6e079e6edc06",
+        "c90d918a-42e4-4c24-81e5-98803cb90423",
+        "86c14847-1e8f-466a-93ed-719f5b0f02b4"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "de",
+      "display_name": "Germany",
+      "aliases": [],
+      "mention_count": 37,
+      "sample_question_ids": [
+        "40a6e673-904f-4e5f-9da4-4be9e8a65ca0",
+        "b6296ed4-c6d2-4612-9887-8142fbdf1141",
+        "6f27bca6-2d37-425a-b872-d90225dca944",
+        "8be84f0a-07ea-4fa4-a81d-884c28efca85",
+        "a303e331-55c3-460e-8348-28d16f69c77e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "tottenham-hotspur",
+      "display_name": "Tottenham Hotspur",
+      "aliases": [
+        "Tottenham"
+      ],
+      "mention_count": 36,
+      "sample_question_ids": [
+        "f4fb5b28-0dfa-477d-849f-2ca1a5b6922a",
+        "a191f34b-2a64-4129-a657-e862f233c727",
+        "6647cef4-3eeb-4298-8ac3-5b5bdd639932",
+        "8331cded-7f0a-4fe1-86d0-9c08f22d152d",
+        "4f9fe72e-0220-44e3-9ed7-c568cd81dbb1"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-cup",
+      "display_name": "UEFA Cup",
+      "aliases": [],
+      "mention_count": 35,
+      "sample_question_ids": [
+        "4b6899d6-959a-480a-a94d-87ddc26d1ba3",
+        "474c5d85-389e-40cd-a3cb-199fb3355565",
+        "8b5f620c-2f0c-41fe-b0d7-a2188759f99c",
+        "6647cef4-3eeb-4298-8ac3-5b5bdd639932",
+        "948a38d2-3117-40e6-94fe-c7a2ee083060"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "arsenal",
+      "display_name": "Arsenal",
+      "aliases": [
+        "Arsenal FC",
+        "The Invincibles",
+        "Gunners",
+        "The Arsenal"
+      ],
+      "mention_count": 33,
+      "sample_question_ids": [
+        "d744b3d2-1cc7-43b3-9869-7aa77b1da74d",
+        "2457034b-e727-4eaa-bfdd-4e09c8143eca",
+        "dcb1dfe2-af5e-4637-ad73-50ed3598435e",
+        "a408032d-5f81-4c9c-8b87-4c7dc9a1a247",
+        "3cbbe333-05bb-443f-a57a-14bfc3d95def"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "manchester-city",
+      "display_name": "Manchester City",
+      "aliases": [
+        "City"
+      ],
+      "mention_count": 31,
+      "sample_question_ids": [
+        "6eb2f422-406c-4926-9c5d-a605c39094ac",
+        "d426bb98-5e9e-494a-b5ce-83417523420f",
+        "fb882f56-7414-44c9-b9d3-e9963bde62db",
+        "f47c28d2-d7e8-48f0-a98c-64be231c0e90",
+        "88567b0f-3942-4c2e-bc13-d3bafbe9408f"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-cup-winners-cup",
+      "display_name": "UEFA Cup Winners' Cup",
+      "aliases": [
+        "Cup Winners' Cup",
+        "European Cup Winners' Cup"
+      ],
+      "mention_count": 30,
+      "sample_question_ids": [
+        "a86dcbff-a4b7-446c-b0ff-6292542ccaba",
+        "63d9b5b9-fe11-49c4-bfcf-512985693cbf",
+        "1dd7900d-0364-4c07-a97b-5670ddd7e4ae",
+        "f7f638f3-4e67-448a-87f5-b0fbe6f458d5",
+        "fbebac3b-75a0-434f-a4bb-84338719e6b5"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "la-liga",
+      "display_name": "La Liga",
+      "aliases": [],
+      "mention_count": 29,
+      "sample_question_ids": [
+        "11f28ed9-05ec-4ff7-8f8b-6ce4aa53e1ff",
+        "6647cef4-3eeb-4298-8ac3-5b5bdd639932",
+        "840b5d5d-d4ad-48b0-885a-409aa7f66e6b",
+        "b6e53047-4615-401d-a3da-4db14fe12dce",
+        "9c2a1bcb-0a57-4d61-a562-4c297ce93b99"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "bundesliga",
+      "display_name": "Bundesliga",
+      "aliases": [
+        "German Bundesliga"
+      ],
+      "mention_count": 28,
+      "sample_question_ids": [
+        "305af037-445a-4175-8544-587a3170a840",
+        "28022225-0dd0-41d7-ba6e-200592cb8958",
+        "10f22af6-d66c-4e97-9abd-933edf6d8791",
+        "6d41cc78-7e43-4503-a825-ad87b4d9a554",
+        "81f4c039-d088-47f7-a180-d0463ae94e22"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ajax",
+      "display_name": "Ajax",
+      "aliases": [
+        "AFC Ajax"
+      ],
+      "mention_count": 27,
+      "sample_question_ids": [
+        "9783dd22-6b15-4f30-bad8-b94af4d5101b",
+        "f4fb5b28-0dfa-477d-849f-2ca1a5b6922a",
+        "71272fe9-7a2e-4b14-a750-740fd7fb8d32",
+        "1dc608f1-70d8-41b8-947c-9545c5a425d3",
+        "c2d95ab7-57fb-4829-bf36-8ee5fdbe6d41"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "pt",
+      "display_name": "Portugal",
+      "aliases": [],
+      "mention_count": 27,
+      "sample_question_ids": [
+        "74d8f203-ce2a-4771-98de-081cee56aa24",
+        "fd7a7d8d-17e4-4e65-8c14-b67e9b6d16eb",
+        "72791ad2-552e-4351-a4d0-04bbe51b2482",
+        "9e149d3b-3c80-4280-b8ed-6b1da0288a30",
+        "539daa85-7bff-4788-bf88-ce21e42d7868"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "borussia-dortmund",
+      "display_name": "Borussia Dortmund",
+      "aliases": [
+        "Dortmund"
+      ],
+      "mention_count": 26,
+      "sample_question_ids": [
+        "10f22af6-d66c-4e97-9abd-933edf6d8791",
+        "6d41cc78-7e43-4503-a825-ad87b4d9a554",
+        "8719b0a8-60f9-406f-84da-f1c89cc7dcba",
+        "cdd7ab12-287e-4809-8a32-4d9f54a53937",
+        "aee2af9f-f93f-4c3f-902b-aea1d0aa755c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "inter-milan",
+      "display_name": "Inter Milan",
+      "aliases": [
+        "Inter"
+      ],
+      "mention_count": 26,
+      "sample_question_ids": [
+        "a71e279d-4bfd-460a-91cf-e4071e3061e3",
+        "2e2845d8-4f22-4f78-bb17-24b5e4613948",
+        "b6296ed4-c6d2-4612-9887-8142fbdf1141",
+        "08f27558-2c73-4302-b78b-e54a8f5090e2",
+        "89557f60-a389-49a6-b2a4-0f91809bcf6e"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "gb",
+      "display_name": "Scotland",
+      "aliases": [
+        "Ireland"
+      ],
+      "mention_count": 26,
+      "sample_question_ids": [
+        "dac066da-a6c3-418a-b9d8-71e3455530e4",
+        "8b5f620c-2f0c-41fe-b0d7-a2188759f99c",
+        "8331cded-7f0a-4fe1-86d0-9c08f22d152d",
+        "508c411a-8e5e-458c-846f-843c3c80daac",
+        "931619ac-ca55-42a5-84e1-af2124c4562d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "celtic",
+      "display_name": "Celtic",
+      "aliases": [
+        "Lisbon Lions",
+        "Celtic FC"
+      ],
+      "mention_count": 24,
+      "sample_question_ids": [
+        "31bbea25-dbc6-45a0-80f7-6c47868fb682",
+        "2e2845d8-4f22-4f78-bb17-24b5e4613948",
+        "c88aaab9-0ecd-4cb8-a055-917434735af7",
+        "1f8a9d4d-9b8a-4344-9be0-81b5c0cae714",
+        "9dd5f454-e3aa-4d26-a35c-65c00cb58e00"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "paris-saint-germain",
+      "display_name": "Paris Saint-Germain",
+      "aliases": [
+        "PSG"
+      ],
+      "mention_count": 24,
+      "sample_question_ids": [
+        "2ca872a2-d486-44da-9c53-0495aaa53f48",
+        "c916fcaa-31c3-4807-a486-a4b8606cad71",
+        "be2d99e9-ff64-4808-829a-bab3a93f9051",
+        "38ba72bc-06bc-4113-a4dc-a993f4f9d751",
+        "0356b343-9958-4cb8-bbd7-af599abc76b4"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "fa-cup",
+      "display_name": "FA Cup",
+      "aliases": [],
+      "mention_count": 24,
+      "sample_question_ids": [
+        "d426bb98-5e9e-494a-b5ce-83417523420f",
+        "2457034b-e727-4eaa-bfdd-4e09c8143eca",
+        "bf4e012f-941a-477e-a6c0-f588304c72ba",
+        "dfcb2fc6-9657-4b7d-b8e0-ca0cdadcf3d3",
+        "c909c2e0-1360-48fa-9666-75400682a3a2"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "atletico-madrid",
+      "display_name": "Atletico Madrid",
+      "aliases": [
+        "Atletico Madrid"
+      ],
+      "mention_count": 24,
+      "sample_question_ids": [
+        "5b8361a2-7bd0-40dc-9a34-f94c8e1b51e7",
+        "73093a1e-d240-46c5-8b1e-5a5276545fd1",
+        "71c51fd6-4ead-46c6-aeeb-86d523a3f109",
+        "8be84f0a-07ea-4fa4-a81d-884c28efca85",
+        "012bbe03-a99e-4299-bddb-fac12b9a8256"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "it",
+      "display_name": "Italy",
+      "aliases": [],
+      "mention_count": 23,
+      "sample_question_ids": [
+        "a33e971c-f202-495a-af20-6a75666f2293",
+        "a71e279d-4bfd-460a-91cf-e4071e3061e3",
+        "3aeb6565-6863-4751-a806-ea224fb77ccc",
+        "8b23f84d-47ef-4976-9730-5432fab191e2",
+        "bf4e012f-941a-477e-a6c0-f588304c72ba"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ar",
+      "display_name": "Argentina",
+      "aliases": [],
+      "mention_count": 23,
+      "sample_question_ids": [
+        "08be2a6a-61c6-48f5-a103-4a3caa85ace6",
+        "3b4f4a84-7feb-4149-ad2d-47e9e88c7a74",
+        "7c37bb22-c0a9-45d0-831d-afa25f8d2177",
+        "23ffc9c5-4eb2-4e45-b108-6d92587c0863",
+        "948f9610-171a-40c9-b79a-44ff8b770d84"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-europa-league",
+      "display_name": "UEFA Europa League",
+      "aliases": [
+        "Europa League",
+        "UEFA Cup",
+        "Europa League"
+      ],
+      "mention_count": 23,
+      "sample_question_ids": [
+        "a88746d1-3b34-4a4d-ba4d-0223621c2174",
+        "8be84f0a-07ea-4fa4-a81d-884c28efca85",
+        "8719b0a8-60f9-406f-84da-f1c89cc7dcba",
+        "829aeab1-f8f6-4888-8736-77d2a9095971",
+        "b6296ed4-c6d2-4612-9887-8142fbdf1141"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "fr",
+      "display_name": "France",
+      "aliases": [
+        "Marseille"
+      ],
+      "mention_count": 21,
+      "sample_question_ids": [
+        "84f6e2b4-42c3-492b-a599-8907b539a789",
+        "a9959e9d-96b6-4bf8-9bd5-59af9d9fe173",
+        "ce00079f-4f75-442c-96af-11b0ecec676d",
+        "8ed6b8a0-064d-4b84-a96c-68be0054ecdf",
+        "949829cc-843c-4dd3-b269-326a9416d7ec"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "aston-villa",
+      "display_name": "Aston Villa",
+      "aliases": [
+        "Aston Villa FC"
+      ],
+      "mention_count": 21,
+      "sample_question_ids": [
+        "32824002-544c-4e1c-9ed4-7a4aca195878",
+        "c82de618-3f7d-4079-98ad-2f67a8d2db8a",
+        "1cbcbd41-6bdb-4278-aa90-c29a7d90068a",
+        "b86e786d-727c-4d35-a763-30df6b8ffd20",
+        "37b0a5a9-c59b-4d89-a764-ef812311ff12"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "olympique-marseille",
+      "display_name": "Olympique Marseille",
+      "aliases": [
+        "Marseille"
+      ],
+      "mention_count": 20,
+      "sample_question_ids": [
+        "00e373bd-9099-4983-95a3-b14961a6c4f8",
+        "a9959e9d-96b6-4bf8-9bd5-59af9d9fe173",
+        "91a18fdc-a3eb-43fc-89d4-c186cfafb1a8",
+        "eff497a5-2b4a-444e-8ef0-8ece43da102f",
+        "dfc8d044-af9b-44fe-a0de-dd27df0f0afc"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "as-roma",
+      "display_name": "AS Roma",
+      "aliases": [
+        "Roma"
+      ],
+      "mention_count": 20,
+      "sample_question_ids": [
+        "3b498b3f-8dee-42cc-8c39-86b072eafa41",
+        "bdf522c7-0c00-4833-8b25-2873813fba8e",
+        "4829ee2f-5c26-45ac-82d1-e2488c70b576",
+        "ea715857-1fcb-4543-8e09-87419bcaa683",
+        "e1a09b22-f9d0-42c0-8147-8359536b6cc0"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "brazil-national-football-team",
+      "display_name": "Brazil national football team",
+      "aliases": [
+        "Brazil",
+        "Brazil national team"
+      ],
+      "mention_count": 19,
+      "sample_question_ids": [
+        "b2c07c4b-2bad-4a45-8121-60a8bd9e903a",
+        "2a03c7b3-fdc1-4b48-b94e-c1c4e859fa9e",
+        "c857adf0-33b0-4311-9af2-504bf876f357",
+        "1729a34e-edb1-47e8-9df5-265e490a16f6",
+        "4f25010d-ca81-43b8-9a7b-8f83ba4fea78"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "lionel-messi",
+      "display_name": "Lionel Messi",
+      "aliases": [
+        "Messi",
+        "Leo Messi"
+      ],
+      "mention_count": 18,
+      "sample_question_ids": [
+        "2a929c0d-baeb-40aa-a93d-bc23780bb019",
+        "bf4e012f-941a-477e-a6c0-f588304c72ba",
+        "9c2a1bcb-0a57-4d61-a562-4c297ce93b99",
+        "ac409224-d2dd-484e-8c2f-d5b8c4b4b5e9",
+        "3295d37f-2dcc-4b91-9248-f4f0ec47bd0c"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "nl",
+      "display_name": "Netherlands",
+      "aliases": [],
+      "mention_count": 17,
+      "sample_question_ids": [
+        "8076c232-b9b0-4cb7-b65c-bb012ce89cf5",
+        "d1b12993-7530-4f83-b8c9-c94b3d0d96aa",
+        "e9f00fc1-748e-459e-91f8-49014245965c",
+        "84b9bade-a4ed-4788-bb81-08199fb66284",
+        "24ccf049-278b-4332-b5b5-99285969b5ba"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "gr",
+      "display_name": "Greece",
+      "aliases": [],
+      "mention_count": 17,
+      "sample_question_ids": [
+        "74d8f203-ce2a-4771-98de-081cee56aa24",
+        "fd7a7d8d-17e4-4e65-8c14-b67e9b6d16eb",
+        "891b7d27-2a8a-480d-bd64-c5cc7e49ad2e",
+        "bf4e012f-941a-477e-a6c0-f588304c72ba",
+        "8f54b9e3-755f-4ade-a79e-8fe98c0a1818"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "feyenoord",
+      "display_name": "Feyenoord",
+      "aliases": [],
+      "mention_count": 16,
+      "sample_question_ids": [
+        "d55c5cb0-ec13-4cbc-82b0-427c112fdb8a",
+        "125511a3-8f77-4098-9ba7-2b8594fdba14",
+        "5079b594-28b0-466d-a3e1-53a4c2245cc1",
+        "a7a3aa51-ade9-4c7d-883d-69e050620268",
+        "4b94d628-937f-4c93-9c96-83501604d324"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "germany-national-team",
+      "display_name": "Germany",
+      "aliases": [
+        "Germany national team"
+      ],
+      "mention_count": 16,
+      "sample_question_ids": [
+        "47ad85fd-ff12-4c02-8765-49742a8a477a",
+        "430a07e1-f195-4bbc-8111-0796d58ea849",
+        "a39a8730-ee4e-41b2-8bdd-52b5b36fe87d",
+        "1729a34e-edb1-47e8-9df5-265e490a16f6",
+        "931619ac-ca55-42a5-84e1-af2124c4562d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ssc-napoli",
+      "display_name": "S.S.C. Napoli",
+      "aliases": [
+        "Napoli"
+      ],
+      "mention_count": 16,
+      "sample_question_ids": [
+        "50891205-590e-4e82-939f-b51db66ffa3d",
+        "cf211da0-f240-4fec-b7a5-6b9cc2c24291",
+        "23495c2c-2946-46bc-9ef2-1cdb97e7b469",
+        "834a055d-8ec2-42e0-af1b-035d2edc7b77",
+        "e96f6e95-2bf0-4907-b046-4d168f4c7b90"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "as-monaco",
+      "display_name": "AS Monaco",
+      "aliases": [
+        "Monaco"
+      ],
+      "mention_count": 15,
+      "sample_question_ids": [
+        "15615c14-4952-42d7-907d-4575e36e07e0",
+        "e12f6f17-fbe6-4bc9-9932-3c067f21201e",
+        "2126122c-6781-4891-b855-8a3a8a0a69fd",
+        "c471b212-bcec-48ba-b621-7d9817a0b4bf",
+        "d3c63983-71b0-425b-a84c-7f453fb5914c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-porto",
+      "display_name": "FC Porto",
+      "aliases": [
+        "Porto"
+      ],
+      "mention_count": 15,
+      "sample_question_ids": [
+        "15615c14-4952-42d7-907d-4575e36e07e0",
+        "59b5131f-834c-40d0-b820-67c8dc7622c2",
+        "cfa96cb2-0fd2-42ee-9d71-e482fe9a37f8",
+        "54aefaa6-3a28-4833-b058-708cc19854c6",
+        "e12f6f17-fbe6-4bc9-9932-3c067f21201e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sl-benfica",
+      "display_name": "SL Benfica",
+      "aliases": [
+        "Benfica"
+      ],
+      "mention_count": 15,
+      "sample_question_ids": [
+        "b31d9b3a-3e3d-4484-99a8-4e16362aa346",
+        "5a7126a5-ab19-4b34-94d0-bfd3dea08998",
+        "829aeab1-f8f6-4888-8736-77d2a9095971",
+        "2f5fcab3-99e9-4579-991a-607b000937d3",
+        "43917ed5-7053-4956-9843-6e4085eb1712"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "copa-del-rey",
+      "display_name": "Copa del Rey",
+      "aliases": [],
+      "mention_count": 14,
+      "sample_question_ids": [
+        "b7e52a06-ad42-4e23-8cb1-6b82e9454069",
+        "bf4e012f-941a-477e-a6c0-f588304c72ba",
+        "5b8361a2-7bd0-40dc-9a34-f94c8e1b51e7",
+        "73093a1e-d240-46c5-8b1e-5a5276545fd1",
+        "aac220bc-cf92-4c2f-8353-ba05b8521e89"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "es",
+      "display_name": "Spain",
+      "aliases": [
+        "Madrid"
+      ],
+      "mention_count": 14,
+      "sample_question_ids": [
+        "b7e52a06-ad42-4e23-8cb1-6b82e9454069",
+        "e9f00fc1-748e-459e-91f8-49014245965c",
+        "03d3e0d2-0ac1-4ab0-95b9-87a4f1a78982",
+        "a3a160ae-d78e-43ef-8f04-ccd17aa003aa",
+        "871fbb34-b261-46ea-85d6-f9f9c7566c6f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "west-ham-united",
+      "display_name": "West Ham United",
+      "aliases": [
+        "West Ham"
+      ],
+      "mention_count": 14,
+      "sample_question_ids": [
+        "2457034b-e727-4eaa-bfdd-4e09c8143eca",
+        "2b0542bf-5aa3-4186-ad3d-14307f377cc4",
+        "05c454cc-341d-4e4d-8c3e-5e0bc269266f",
+        "6647cef4-3eeb-4298-8ac3-5b5bdd639932",
+        "b86e786d-727c-4d35-a763-30df6b8ffd20"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "everton",
+      "display_name": "Everton",
+      "aliases": [
+        "Everton",
+        "Everton FC"
+      ],
+      "mention_count": 14,
+      "sample_question_ids": [
+        "2edc1b10-b7ed-42d1-bfa9-4cc48c2d2af3",
+        "fedef61f-b296-4626-8267-dbbfd48fdade",
+        "1ad72303-fde7-41fe-9bf1-76d9f8d89682",
+        "54a7017f-b304-4eaa-99eb-cdcf8518af3f",
+        "fbebac3b-75a0-434f-a4bb-84338719e6b5"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "psv-eindhoven",
+      "display_name": "PSV Eindhoven",
+      "aliases": [],
+      "mention_count": 13,
+      "sample_question_ids": [
+        "9db8e4c5-1e00-4fdf-b2eb-f742a502f524",
+        "2f5fcab3-99e9-4579-991a-607b000937d3",
+        "0cd8ba2b-66da-48a2-a472-a3f5bf4089f8",
+        "f03fdd1c-a37a-4c3a-a51e-1d7d54d42cd3",
+        "ddb26811-8435-470f-a2cb-ee4ed1eebcd0"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "newcastle-united",
+      "display_name": "Newcastle United",
+      "aliases": [
+        "Newcastle"
+      ],
+      "mention_count": 13,
+      "sample_question_ids": [
+        "94855a13-1a9c-4c37-a81b-300cae4a1b3d",
+        "362337c6-b9a3-46bc-8a31-31dc6a1bb25e",
+        "32824002-544c-4e1c-9ed4-7a4aca195878",
+        "24d8aed3-3153-415a-9bde-be94dd34b7d8",
+        "4bab35de-f46f-4d88-b58d-77eb2482b20a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "lazio",
+      "display_name": "Lazio",
+      "aliases": [
+        "S.S. Lazio",
+        "SS Lazio"
+      ],
+      "mention_count": 13,
+      "sample_question_ids": [
+        "ef0a0fd4-0e28-4ca2-a809-42c5e712009e",
+        "90410a42-a8fd-496e-bbbd-9b04a8e5d256",
+        "4573a286-8675-463b-ac83-893ee1f6f3f6",
+        "ed459602-d2af-4972-a78f-16dbb2e57288",
+        "d4555376-e321-4e51-a357-6a5f0ad78e3d"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "tr",
+      "display_name": "Turkey",
+      "aliases": [
+        "Istanbul"
+      ],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "62c4c1aa-729b-4ca9-8abd-9c5478532ebf",
+        "097a3848-8bc6-44c8-969c-a7dd931d1628",
+        "f851503c-07fb-4dc3-abd5-04df26cffeb3",
+        "89718799-b621-4fd5-9ab3-68873df04b70",
+        "7d7befa8-482a-42cb-abf8-299f72486cd1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "middlesbrough",
+      "display_name": "Middlesbrough",
+      "aliases": [],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "d1b12993-7530-4f83-b8c9-c94b3d0d96aa",
+        "9db8e4c5-1e00-4fdf-b2eb-f742a502f524",
+        "36bc6b0e-79a6-495e-ab45-85c845746d02",
+        "90410a42-a8fd-496e-bbbd-9b04a8e5d256",
+        "89675e1a-fa3d-4e1a-a2e3-aa394897387a"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "ligue-1",
+      "display_name": "Ligue 1",
+      "aliases": [],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "85a1a10d-fdfa-4478-9d9b-5b0ac03b276d",
+        "c96cd7a2-9627-4e29-9715-18977edf80da",
+        "c8317df9-8447-44a6-ac7a-461009429bb7",
+        "2126122c-6781-4891-b855-8a3a8a0a69fd",
+        "fcd3a0e8-583c-4c14-b8f3-b2e61c21bb4f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "cristiano-ronaldo",
+      "display_name": "Cristiano Ronaldo",
+      "aliases": [],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "83e5dbad-b036-4fac-bfc3-57642f330171",
+        "cfec34dc-5f17-4f0a-850b-c5a0d23e698b",
+        "e6c7e742-fd0b-4ab6-b978-fe9a32d42d28",
+        "d7323022-2c7f-403b-a319-e086d26a5d38",
+        "47198e04-0b08-4c0d-9dc4-511344a11695"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "werder-bremen",
+      "display_name": "Werder Bremen",
+      "aliases": [
+        "Werder Bremen"
+      ],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "305af037-445a-4175-8544-587a3170a840",
+        "948a38d2-3117-40e6-94fe-c7a2ee083060",
+        "4b1cd9f2-a448-4e9a-960c-768b02569359",
+        "9427602a-7c09-4e68-b471-3a051c1d6a88",
+        "7ba80b85-430c-4222-a0cc-9dec6b05b83a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fiorentina",
+      "display_name": "Fiorentina",
+      "aliases": [
+        "ACF Fiorentina"
+      ],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "a58d5ccd-47a4-436b-928e-74195543af30",
+        "a33e971c-f202-495a-af20-6a75666f2293",
+        "c90d918a-42e4-4c24-81e5-98803cb90423",
+        "45ec50c2-f636-47fa-b85a-a95d0a6ad784",
+        "1dd7900d-0364-4c07-a97b-5670ddd7e4ae"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "nottingham-forest",
+      "display_name": "Nottingham Forest",
+      "aliases": [],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "6f145f2b-e46d-457c-8530-46db44a58c22",
+        "dd4a0dd8-65c1-4cef-957d-acbd4c81275d",
+        "dd2ba86e-26c8-4241-a2f5-86047e882bd1",
+        "c02fef94-309a-4889-aefc-a57d013be510",
+        "d26ec8cb-112d-4b0c-950a-61765b4646b9"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "coppa-italia",
+      "display_name": "Coppa Italia",
+      "aliases": [],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "bf4e012f-941a-477e-a6c0-f588304c72ba",
+        "19831ab4-b052-4357-ad2f-b9cc94057b98",
+        "ff5ff99e-982b-4737-98df-506353fa7d6a",
+        "5a6fb4a6-32c9-439e-9953-0aa3250d3b3b",
+        "27fe0d2f-1bc3-46a4-8e8c-dd9d9457a890"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "galatasaray-sk",
+      "display_name": "Galatasaray SK",
+      "aliases": [
+        "Galatasaray"
+      ],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "96dc7442-28d3-46a4-bdae-9e01941de36f",
+        "c8bbe39e-a9d6-404c-bc4a-dc64274ae403",
+        "68b6c454-4587-443b-af51-3f68e524d396",
+        "456fe693-e58c-45d5-827c-431a9a9d13ec",
+        "f851503c-07fb-4dc3-abd5-04df26cffeb3"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "olympiacos-piraeus",
+      "display_name": "Olympiacos Piraeus",
+      "aliases": [
+        "Olympiacos F.C.",
+        "Olympiacos"
+      ],
+      "mention_count": 12,
+      "sample_question_ids": [
+        "084fd73d-a621-4768-abf7-1454f2fa0d1b",
+        "f4599371-7517-47c7-a7c3-63ca3c64ff4e",
+        "72d7eea4-50f7-483f-82e6-8f7f03099bb1",
+        "891b7d27-2a8a-480d-bd64-c5cc7e49ad2e",
+        "68ab4348-2102-4daf-a884-e47cdf022d3a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sevilla",
+      "display_name": "Sevilla FC",
+      "aliases": [],
+      "mention_count": 11,
+      "sample_question_ids": [
+        "fb3711a2-1dde-43d1-a9fe-423b83f1903f",
+        "8b5f620c-2f0c-41fe-b0d7-a2188759f99c",
+        "6647cef4-3eeb-4298-8ac3-5b5bdd639932",
+        "b6296ed4-c6d2-4612-9887-8142fbdf1141",
+        "63f2427e-2efe-408a-b1e5-1997711bba8f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "west-germany",
+      "display_name": "West Germany",
+      "aliases": [],
+      "mention_count": 11,
+      "sample_question_ids": [
+        "8076c232-b9b0-4cb7-b65c-bb012ce89cf5",
+        "7f5fda83-12ed-4cf8-ba3e-5c0bfd4c35b1",
+        "8aa08ab8-da24-4c40-bede-9d1ad83f6a8f",
+        "948f9610-171a-40c9-b79a-44ff8b770d84",
+        "7418bc47-2f82-47f3-8e8b-f569d1825b8e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "rangers",
+      "display_name": "Rangers FC",
+      "aliases": [
+        "Rangers FC"
+      ],
+      "mention_count": 11,
+      "sample_question_ids": [
+        "dac066da-a6c3-418a-b9d8-71e3455530e4",
+        "1dd7900d-0364-4c07-a97b-5670ddd7e4ae",
+        "c88aaab9-0ecd-4cb8-a055-917434735af7",
+        "50f6b87e-24f8-4e45-9aa0-5598529b5d0a",
+        "a1c1a80e-1c1d-4497-ae5c-1c3429421403"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "jose-mourinho",
+      "display_name": "José Mourinho",
+      "aliases": [],
+      "mention_count": 11,
+      "sample_question_ids": [
+        "15615c14-4952-42d7-907d-4575e36e07e0",
+        "e12f6f17-fbe6-4bc9-9932-3c067f21201e",
+        "63f2427e-2efe-408a-b1e5-1997711bba8f",
+        "7f382f3a-2e00-4e55-8bea-4c42ee6a4dc0",
+        "2747caff-63d7-4a83-a51a-e349c76dbe27"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "br",
+      "display_name": "Brazil",
+      "aliases": [],
+      "mention_count": 11,
+      "sample_question_ids": [
+        "84b9bade-a4ed-4788-bb81-08199fb66284",
+        "327ed3ed-2f99-4aa3-9ddc-eff0a5cdff36",
+        "3ecb6bdd-df8b-46eb-aae2-57d4fd1e8cfc",
+        "e93ed45f-f162-4752-ba0c-c39daaf99a98",
+        "e0416421-b08c-4b48-af1c-16b6cefebb13"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "valencia",
+      "display_name": "Valencia",
+      "aliases": [
+        "Valencia CF",
+        "Valencia"
+      ],
+      "mention_count": 10,
+      "sample_question_ids": [
+        "b7e52a06-ad42-4e23-8cb1-6b82e9454069",
+        "74bd9094-4d42-4a46-9e68-907fa4d6dd12",
+        "ba8ac674-96b0-4aa7-a6e2-cadee88d0b2f",
+        "aac220bc-cf92-4c2f-8353-ba05b8521e89",
+        "63f2427e-2efe-408a-b1e5-1997711bba8f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "argentina",
+      "display_name": "Argentina",
+      "aliases": [],
+      "mention_count": 10,
+      "sample_question_ids": [
+        "c857adf0-33b0-4311-9af2-504bf876f357",
+        "3aeb6565-6863-4751-a806-ea224fb77ccc",
+        "327ed3ed-2f99-4aa3-9ddc-eff0a5cdff36",
+        "43e3319f-d868-483c-a0c1-2da17c6d2990",
+        "8aa08ab8-da24-4c40-bede-9d1ad83f6a8f"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "ballon-dor",
+      "display_name": "Ballon d'Or",
+      "aliases": [],
+      "mention_count": 10,
+      "sample_question_ids": [
+        "86c14847-1e8f-466a-93ed-719f5b0f02b4",
+        "38ba72bc-06bc-4113-a4dc-a993f4f9d751",
+        "8906406f-6475-4853-80f5-979d434f09da",
+        "902c1d59-fa6d-4ef7-9ddf-3dff32f6745b",
+        "e6c7e742-fd0b-4ab6-b978-fe9a32d42d28"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "greek-super-league",
+      "display_name": "Greek Super League",
+      "aliases": [
+        "Super League Greece"
+      ],
+      "mention_count": 9,
+      "sample_question_ids": [
+        "9e4764c1-1b37-4a9a-945b-455079b79aee",
+        "f4599371-7517-47c7-a7c3-63ca3c64ff4e",
+        "72d7eea4-50f7-483f-82e6-8f7f03099bb1",
+        "68ab4348-2102-4daf-a884-e47cdf022d3a",
+        "e0914b41-a95e-4958-9c86-b8339195414b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "diego-maradona",
+      "display_name": "Diego Maradona",
+      "aliases": [],
+      "mention_count": 9,
+      "sample_question_ids": [
+        "cf211da0-f240-4fec-b7a5-6b9cc2c24291",
+        "3b4f4a84-7feb-4149-ad2d-47e9e88c7a74",
+        "8aa08ab8-da24-4c40-bede-9d1ad83f6a8f",
+        "ba69a45b-fb87-497b-9154-b8320c1f1970",
+        "23495c2c-2946-46bc-9ef2-1cdb97e7b469"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "dfb-pokal",
+      "display_name": "DFB-Pokal",
+      "aliases": [],
+      "mention_count": 9,
+      "sample_question_ids": [
+        "10f22af6-d66c-4e97-9abd-933edf6d8791",
+        "bf4e012f-941a-477e-a6c0-f588304c72ba",
+        "af3cc0fc-ce33-4655-8432-f569d1c8a75f",
+        "f669a9de-531a-44c8-9ec9-1755b06b263d",
+        "5816c6fe-7730-4724-a8e5-2e987c84f544"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gerd-muller",
+      "display_name": "Gerd Müller",
+      "aliases": [],
+      "mention_count": 9,
+      "sample_question_ids": [
+        "40a6e673-904f-4e5f-9da4-4be9e8a65ca0",
+        "bf4e012f-941a-477e-a6c0-f588304c72ba",
+        "ddc6db2b-c675-49d5-acec-e1dcc92de693",
+        "5aeed165-c738-4ba8-be04-1d097cdd8aa3",
+        "f669a9de-531a-44c8-9ec9-1755b06b263d"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "eredivisie",
+      "display_name": "Eredivisie",
+      "aliases": [],
+      "mention_count": 9,
+      "sample_question_ids": [
+        "27b6ee4e-d7c7-4895-8e2a-15aa52c56fb6",
+        "9a764629-6d13-4848-ab31-b2de5d070b65",
+        "b8dd6713-1bc5-4bd2-bbf2-ef48b14a2761",
+        "86a53d23-13fc-439e-b380-1545c2c43729",
+        "6893e81b-0acf-402b-a918-09acb9be4777"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fk-crvena-zvezda",
+      "display_name": "FK Crvena zvezda",
+      "aliases": [
+        "Red Star Belgrade",
+        "Crvena Zvezda"
+      ],
+      "mention_count": 9,
+      "sample_question_ids": [
+        "ef94e1a6-9bea-4e8a-a7b9-fcfa4975f797",
+        "044467f2-cdd8-4166-a9d7-6c5f583b60ed",
+        "7220293c-afc4-4583-b1be-053065452ef8",
+        "98a84530-da55-4c99-8d05-dba0e842247b",
+        "25687d54-4342-4532-94f5-f3b6faacaee8"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "thierry-henry",
+      "display_name": "Thierry Henry",
+      "aliases": [],
+      "mention_count": 8,
+      "sample_question_ids": [
+        "d744b3d2-1cc7-43b3-9869-7aa77b1da74d",
+        "e0e079a8-d914-4e69-b5e8-8a1cfa7d674c",
+        "bf4e012f-941a-477e-a6c0-f588304c72ba",
+        "a408032d-5f81-4c9c-8b87-4c7dc9a1a247",
+        "c36b4340-3367-40b2-a213-555f8deecd01"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sampdoria",
+      "display_name": "Sampdoria",
+      "aliases": [],
+      "mention_count": 8,
+      "sample_question_ids": [
+        "a191f34b-2a64-4129-a657-e862f233c727",
+        "0a2e8630-6020-47e8-9534-3bd3f2e288e4",
+        "758a7e8f-7218-4ca9-9f9e-3c375b66c498",
+        "a8d954d4-a71a-4da8-9b38-981cd9a7e022",
+        "d4555376-e321-4e51-a357-6a5f0ad78e3d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "borussia-monchengladbach",
+      "display_name": "Borussia Mönchengladbach",
+      "aliases": [
+        "Die Fohlen"
+      ],
+      "mention_count": 8,
+      "sample_question_ids": [
+        "18acd94a-03ee-4bb1-9c90-c16a6166823d",
+        "9427602a-7c09-4e68-b471-3a051c1d6a88",
+        "6fb5d47c-dc34-4a5c-8234-b5cc2a239a95",
+        "b74c9319-29f8-462c-80bd-989d41cf1ad9",
+        "f69a0810-a1d7-4dc5-b02d-20052f2b071b"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "leeds-united",
+      "display_name": "Leeds United",
+      "aliases": [],
+      "mention_count": 8,
+      "sample_question_ids": [
+        "dd4a0dd8-65c1-4cef-957d-acbd4c81275d",
+        "bd8ea8e4-2d65-4864-bdcf-ecf043d0d855",
+        "b41d63a6-18c4-4ad3-aa56-c2e4fa6acdf5",
+        "0fa83543-b616-4e37-aedf-823f3260571b",
+        "ea66a753-6dc7-4ed3-ad2e-a4c12474cda2"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "premier-league",
+      "display_name": "Premier League",
+      "aliases": [],
+      "mention_count": 8,
+      "sample_question_ids": [
+        "25687d54-4342-4532-94f5-f3b6faacaee8",
+        "4c2a422c-4427-4fba-8986-1ae5e8ed1e43",
+        "9e14697a-16f4-4f19-a25b-5862dd6e0518",
+        "653f05f2-543b-445b-b743-e09fbc3c467f",
+        "a7a3aa51-ade9-4c7d-883d-69e050620268"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "olympique-lyonnais",
+      "display_name": "Olympique Lyonnais",
+      "aliases": [
+        "Lyon",
+        "Olympique Lyon"
+      ],
+      "mention_count": 8,
+      "sample_question_ids": [
+        "c916fcaa-31c3-4807-a486-a4b8606cad71",
+        "6647cef4-3eeb-4298-8ac3-5b5bdd639932",
+        "fcd3a0e8-583c-4c14-b8f3-b2e61c21bb4f",
+        "85a1a10d-fdfa-4478-9d9b-5b0ac03b276d",
+        "6aec5c73-bbcc-4d75-b97c-a7eabd70ba9a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sporting-cp",
+      "display_name": "Sporting CP",
+      "aliases": [
+        "Sporting Clube de Portugal"
+      ],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "63d9b5b9-fe11-49c4-bfcf-512985693cbf",
+        "54aefaa6-3a28-4833-b058-708cc19854c6",
+        "8b23f84d-47ef-4976-9730-5432fab191e2",
+        "3ba8fdda-c32a-4ae1-8a84-6ec46f0a2a09",
+        "a24c4a67-6385-4354-83ae-6c8ebb7d7989"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fenerbahce",
+      "display_name": "Fenerbahçe S.K.",
+      "aliases": [],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "62c4c1aa-729b-4ca9-8abd-9c5478532ebf",
+        "fa213330-f85a-48ff-9b58-9917e989866f",
+        "5a4fe639-4f5d-4c95-8ede-4966de5b4b6d",
+        "96dc7442-28d3-46a4-bdae-9e01941de36f",
+        "6893e81b-0acf-402b-a918-09acb9be4777"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "hamburger-sv",
+      "display_name": "Hamburger SV",
+      "aliases": [],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "28022225-0dd0-41d7-ba6e-200592cb8958",
+        "ceeb7aba-4290-41ca-a77c-34322e84198a",
+        "9dcb84bf-7b47-4ba0-80bd-b080dcd583ea",
+        "4b94d628-937f-4c93-9c96-83501604d324",
+        "a27b4ba4-7e14-43e8-a89c-57df94958d9a"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "premier-league-golden-boot",
+      "display_name": "Premier League Golden Boot",
+      "aliases": [
+        "Golden Boot"
+      ],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "e0e079a8-d914-4e69-b5e8-8a1cfa7d674c",
+        "132e26d2-0523-4a5d-870a-706c9634c103",
+        "536bc997-35ec-4fd7-8fc8-a235cad0a0df",
+        "cfec34dc-5f17-4f0a-850b-c5a0d23e698b",
+        "8331cded-7f0a-4fe1-86d0-9c08f22d152d"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "jp",
+      "display_name": "Japan",
+      "aliases": [],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "1729a34e-edb1-47e8-9df5-265e490a16f6",
+        "4f25010d-ca81-43b8-9a7b-8f83ba4fea78",
+        "8e22fdec-0a2a-454f-b277-f43a68a62dfd",
+        "0ff2e137-98eb-4737-9eec-923cf8dafc44",
+        "2091d434-a9cd-45d1-acfc-3f7d4a5a61b7"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "spain",
+      "display_name": "Spain",
+      "aliases": [],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "dadfc50a-55a8-45e4-89e8-63c86b9a3e08",
+        "50b3b43e-cf0c-4bb5-9085-d289dbb7ff23",
+        "9aa36877-73ed-4bb2-9a62-048e024538d1",
+        "82fd8315-7fb4-4960-8b16-0eb6ecdd1f32",
+        "7a688c9c-dbdb-4c9b-8348-76ab0c3d8fe7"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "vfb-stuttgart",
+      "display_name": "VfB Stuttgart",
+      "aliases": [
+        "Stuttgart"
+      ],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "9427602a-7c09-4e68-b471-3a051c1d6a88",
+        "23495c2c-2946-46bc-9ef2-1cdb97e7b469",
+        "8d7d2bf9-2289-49ab-83bc-9a989e126811",
+        "e96f6e95-2bf0-4907-b046-4d168f4c7b90",
+        "6cdd50fa-40aa-4b51-b331-29b26e78a5f5"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sunderland",
+      "display_name": "Sunderland",
+      "aliases": [],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "2c0769a9-08fa-4930-9d45-3bc934ae6200",
+        "50f6b87e-24f8-4e45-9aa0-5598529b5d0a",
+        "41a00928-46a3-455a-a963-da7481bd0a5e",
+        "50f07e19-b233-4eb1-a323-d8903321d343",
+        "d2a7c41b-a41a-4d29-84f0-ec51e386ecbf"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "athletic-bilbao",
+      "display_name": "Athletic Bilbao",
+      "aliases": [],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "3d72ac91-2fed-4645-9651-0aaf2134ea69",
+        "7c2c328d-6716-454f-9143-f4c9734c73b5",
+        "69ae2273-f161-499f-b971-6af16a7b65cd",
+        "b3d2e72e-920a-40e4-b174-111a73d6f287",
+        "40e43f32-5406-493a-8bef-c47039d23fbd"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "france-national-football-team",
+      "display_name": "France national football team",
+      "aliases": [
+        "France"
+      ],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "e160fbdd-6192-4d44-bab7-3c43b32b4700",
+        "81a3e57d-7f44-4a6d-8fe0-0cebaa2b8908",
+        "617b0c68-a5a3-4107-9f00-0434516f9e31",
+        "8b4479e1-59cb-4836-a34e-4caa328637f9",
+        "2b57c2a9-2758-402e-9d15-545d2ff8aa89"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "neymar-jr",
+      "display_name": "Neymar Jr.",
+      "aliases": [
+        "Neymar"
+      ],
+      "mention_count": 7,
+      "sample_question_ids": [
+        "72331454-7bfa-486d-ab7d-31bd8d8c55ca",
+        "ac409224-d2dd-484e-8c2f-d5b8c4b4b5e9",
+        "e1e00d14-9b4c-4518-95cc-6a3f51472e62",
+        "3ecb6bdd-df8b-46eb-aae2-57d4fd1e8cfc",
+        "d4e99e9f-adbc-4b31-9fc7-4df1695d2a21"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "johan-cruyff",
+      "display_name": "Johan Cruyff",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "a140ee10-bdc4-42a2-8e9c-388b30563854",
+        "11f28ed9-05ec-4ff7-8f8b-6ce4aa53e1ff",
+        "0a2e8630-6020-47e8-9534-3bd3f2e288e4",
+        "a8d954d4-a71a-4da8-9b38-981cd9a7e022",
+        "723d1bf3-4d38-4af2-980b-ef8e97d7f50c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "zlatan-ibrahimovic",
+      "display_name": "Zlatan Ibrahimović",
+      "aliases": [
+        "Ibrahimović"
+      ],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "2ca872a2-d486-44da-9c53-0495aaa53f48",
+        "89557f60-a389-49a6-b2a4-0f91809bcf6e",
+        "ac409224-d2dd-484e-8c2f-d5b8c4b4b5e9",
+        "326452be-bd8f-499e-90ae-ecb5c872f1af",
+        "631b61ff-036c-4a39-8900-b7598e3ce0d9"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "saint-etienne",
+      "display_name": "Saint-Étienne",
+      "aliases": [
+        "AS Saint-Étienne"
+      ],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "e9ca6402-d177-4902-aff9-2a27dd2485a8",
+        "85a1a10d-fdfa-4478-9d9b-5b0ac03b276d",
+        "e64162d5-b170-4671-9abf-3245db9e0bd0",
+        "c96cd7a2-9627-4e29-9715-18977edf80da",
+        "fbed23b4-f4e0-476d-9884-079dc1b6a7d8"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "copa-america",
+      "display_name": "Copa América",
+      "aliases": [
+        "Campeonato Sudamericano de Football"
+      ],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "c857adf0-33b0-4311-9af2-504bf876f357",
+        "dc90203a-f9da-4f87-afaf-a573b54128d7",
+        "607820bb-b1ad-4b50-b2c3-9df46700ca93",
+        "2a03c7b3-fdc1-4b48-b94e-c1c4e859fa9e",
+        "a7371555-f6ee-4138-aa48-8576d63d404c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "parma",
+      "display_name": "Parma",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "eae44df1-2661-4fb1-921b-8028c317e9fa",
+        "4447e6cb-3434-43a4-bcd5-7b24df278b97",
+        "d4555376-e321-4e51-a357-6a5f0ad78e3d",
+        "9554089d-a642-4ce6-a1f4-cbc5dc3579a4",
+        "26542985-30d1-43bb-a73a-1b575399adf0"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "no",
+      "display_name": "Norway",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "5ed0755f-0945-43c7-822a-7547769534b5",
+        "201c69d9-0a02-4520-9629-16d24aa449ce",
+        "5ae0d7fd-6cc0-470c-bd06-9b511682e48f",
+        "1e5637ff-87f4-4196-8b39-5e3792f29af6",
+        "448f19cf-5875-40f5-95e1-b681debdffdd"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "us",
+      "display_name": "USA",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "f42de32d-8cbe-4202-8cb4-b4353114df90",
+        "4cb3538b-b7cc-45ce-ac4b-de58ad83070a",
+        "efa62e65-46d6-4317-9602-4443987a01dc",
+        "6183fbaf-70cd-4888-896e-3f88222a25dd",
+        "de4cb0da-7ec6-4cb1-924b-669e1147a65a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "crystal-palace",
+      "display_name": "Crystal Palace",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "80399952-19e6-478f-9826-185d41435d23",
+        "214cfeab-4cde-4388-ae4b-4bb46b851e5e",
+        "41a00928-46a3-455a-a963-da7481bd0a5e",
+        "0fa83543-b616-4e37-aedf-823f3260571b",
+        "49bd4502-7688-404d-b070-916b42fc728e"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "hr",
+      "display_name": "Croatia",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "1f691183-31f2-43ec-a3a5-24f90c9e3904",
+        "81c59505-e2fe-49fd-99f8-fe2ca1e3659c",
+        "4e301038-a0fd-4470-ad1b-72d55555e6dc",
+        "70634bc5-54ea-4047-9b80-24d990bd233f",
+        "c54b9279-3302-443e-8297-11be3f5233ba"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "peter-withe",
+      "display_name": "Peter Withe",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "c82de618-3f7d-4079-98ad-2f67a8d2db8a",
+        "37b0a5a9-c59b-4d89-a764-ef812311ff12",
+        "7e468507-e520-4df8-bbe1-13b76334186a",
+        "a217c888-ef6d-4ce3-8b32-a0beef25edce",
+        "d6adb857-bbf9-4206-a6f8-cca4c495fb73"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "se",
+      "display_name": "Sweden",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "9dd5f454-e3aa-4d26-a35c-65c00cb58e00",
+        "a5ac5d3d-2505-46d5-b156-c904e2491798",
+        "ecbc8f14-3528-42f7-8a73-eca4e2e53e7c",
+        "0abeee8e-8103-4578-9d52-060274581109",
+        "448f19cf-5875-40f5-95e1-b681debdffdd"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "wembley-stadium",
+      "display_name": "Wembley Stadium",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "f68de578-3254-443d-9c91-44f0c65cc74b",
+        "15519b0b-5e17-4a8f-a710-5c0cfc098b55",
+        "01f45429-06ad-4dcd-a552-446c6a8aa564",
+        "11b99e83-3238-4ecf-8037-47db587ed613",
+        "02f3bcb0-e37b-4987-8f90-0ad3ba3392c4"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "blackburn-rovers",
+      "display_name": "Blackburn Rovers",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "201c69d9-0a02-4520-9629-16d24aa449ce",
+        "80e7ea3c-4743-4e34-b6bc-ccbcd60349c1",
+        "653f05f2-543b-445b-b743-e09fbc3c467f",
+        "bbf0d28c-3906-4201-aea8-195d3092a0a5",
+        "8f1662ff-9f8d-4f03-af74-b669ebe58f35"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ipswich-town",
+      "display_name": "Ipswich Town",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "aefd9400-0512-4470-b6bc-1d92eb998106",
+        "50f07e19-b233-4eb1-a323-d8903321d343",
+        "5a10183b-a5c5-4a07-ac3a-7bbe1d60f08a",
+        "c65aec41-e74f-4db7-afdb-62ddffa55165",
+        "9766195d-0df8-48b8-bfc2-db4d1f11141e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "al-hilal",
+      "display_name": "Al-Hilal",
+      "aliases": [],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "72331454-7bfa-486d-ab7d-31bd8d8c55ca",
+        "a2ecf71e-5fa9-4dcc-99dc-1268e25eaa18",
+        "da62d2f0-21bf-45fb-9ede-dfb95ab47bf5",
+        "93d05043-ffc8-488e-abd5-cae3d4f08d94",
+        "627d2930-394e-4140-b64a-2ae9f2a6315f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "greece-national-football-team",
+      "display_name": "Greece national football team",
+      "aliases": [
+        "Greece"
+      ],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "88741ca0-ae4d-44d9-a40b-42d2c31d40c7",
+        "ea9295ff-4103-4c40-adb8-dd370dc7634a",
+        "d29f2b55-2bef-4fac-99e5-25a81916a042",
+        "6703ea52-3364-4661-b74d-3ea01c08043c",
+        "d84c922e-f5f4-462a-aff4-7492962e4367"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "netherlands-national-football-team",
+      "display_name": "Netherlands national football team",
+      "aliases": [
+        "Netherlands"
+      ],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "40a6e673-904f-4e5f-9da4-4be9e8a65ca0",
+        "fe290816-9550-4d81-89e6-fcaebca99775",
+        "f093b857-00e3-46d3-84b7-5174b765fbcd",
+        "dd6c13da-4d44-4b57-8ae9-db3756730ea7",
+        "df88200d-2edc-4db7-9e9c-3de7ff79f668"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "italy-national-team",
+      "display_name": "Italy",
+      "aliases": [
+        "Italy national team"
+      ],
+      "mention_count": 6,
+      "sample_question_ids": [
+        "430a07e1-f195-4bbc-8111-0796d58ea849",
+        "dadfc50a-55a8-45e4-89e8-63c86b9a3e08",
+        "617b0c68-a5a3-4107-9f00-0434516f9e31",
+        "50b3b43e-cf0c-4bb5-9085-d289dbb7ff23",
+        "6a162ede-2c30-4dec-aa36-ceb9994753d1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "dynamo-kyiv",
+      "display_name": "Dynamo Kyiv",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "a86dcbff-a4b7-446c-b0ff-6292542ccaba",
+        "8906406f-6475-4853-80f5-979d434f09da",
+        "086b35db-db7c-45d7-ba08-40f6b1332e02",
+        "20f54c0e-8a12-4185-b3e5-7310af6cbb59",
+        "dfd055cd-727a-4ebf-a086-b141ebe9a743"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "frank-lampard",
+      "display_name": "Frank Lampard",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "2b0542bf-5aa3-4186-ad3d-14307f377cc4",
+        "739992fa-7844-4af2-bfd1-86057a6ebb7c",
+        "6498edd0-64fb-4608-a9c5-181419073ead",
+        "2d4b0818-4569-415e-b06c-b8dda62081df",
+        "99749f8b-1e03-408f-9e26-f93d2323b6d4"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "aberdeen",
+      "display_name": "Aberdeen",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "0dfb6ff3-d1de-4033-916e-1a362652cb83",
+        "c88aaab9-0ecd-4cb8-a055-917434735af7",
+        "cd491e0b-bf4e-40c3-a198-f1235fba6d56",
+        "1d063fd6-0034-4b3c-8067-346ae4aa49b5",
+        "ce91e532-d78c-480e-a58c-9e609f59af0a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "johan-cruyff",
+      "display_name": "Johan Cruyff",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "71272fe9-7a2e-4b14-a750-740fd7fb8d32",
+        "a163b4e4-0fa5-439d-9cb6-a33fd0b21912",
+        "be42a7f0-3f0f-4bf3-98cf-de79c6695549",
+        "9a764629-6d13-4848-ab31-b2de5d070b65",
+        "9cf0e9a7-23e4-4491-aae9-e0cb6c34ec60"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "robert-lewandowski",
+      "display_name": "Robert Lewandowski",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "10f22af6-d66c-4e97-9abd-933edf6d8791",
+        "4c47ece5-5781-4353-8b4b-44db605145dc",
+        "788bb575-75dc-4965-b6e5-a51c0693050d",
+        "d4e99e9f-adbc-4b31-9fc7-4df1695d2a21",
+        "29311c68-029c-4446-b177-7ba2f196719e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alan-shearer",
+      "display_name": "Alan Shearer",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "132e26d2-0523-4a5d-870a-706c9634c103",
+        "653f05f2-543b-445b-b743-e09fbc3c467f",
+        "bbf0d28c-3906-4201-aea8-195d3092a0a5",
+        "99749f8b-1e03-408f-9e26-f93d2323b6d4",
+        "c895b578-0bf5-4387-aaed-4d93399e1b83"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "old-trafford",
+      "display_name": "Old Trafford",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "dcb1dfe2-af5e-4637-ad73-50ed3598435e",
+        "a4aa16b7-8668-480b-aa80-6defa7c70d58",
+        "5d3eae7b-c47e-464c-af44-58b340d824c1",
+        "61cd15c4-cad8-43a2-bc20-f1bf6bfe5095",
+        "bb40a970-b20b-43dc-b0f1-fb039a4c98c6"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "panathinaikos",
+      "display_name": "Panathinaikos",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "f4599371-7517-47c7-a7c3-63ca3c64ff4e",
+        "e0914b41-a95e-4958-9c86-b8339195414b",
+        "32807350-7ad5-489a-938a-9c950aeee1f0",
+        "7cccba65-5715-4c4c-a393-30856d11ebcd",
+        "854c505a-3537-4c14-a795-c12a33d14c44"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "kr",
+      "display_name": "South Korea",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "1729a34e-edb1-47e8-9df5-265e490a16f6",
+        "83fe2fcf-f9b8-4736-b9a0-122900336e16",
+        "4f25010d-ca81-43b8-9a7b-8f83ba4fea78",
+        "8e22fdec-0a2a-454f-b277-f43a68a62dfd",
+        "0ff2e137-98eb-4737-9eec-923cf8dafc44"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ronaldo",
+      "display_name": "Ronaldo",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "1729a34e-edb1-47e8-9df5-265e490a16f6",
+        "387f6134-cecf-46b7-b06f-b6f35a07b1d4",
+        "4bd2e126-a170-4453-9e18-fa88e0d281e0",
+        "d06b9766-c997-49c5-941a-688d46024a57",
+        "b7c2e47d-e652-4526-b577-f0ebfc92ca01"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "rs",
+      "display_name": "Serbia",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "ef94e1a6-9bea-4e8a-a7b9-fcfa4975f797",
+        "7220293c-afc4-4583-b1be-053065452ef8",
+        "8bad682a-ae10-4990-b906-24568c025abd",
+        "19076705-9a1c-406f-be7c-c738f474aa41",
+        "c1cfb4c3-a7c8-4ef6-a220-88d1e7c7153d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "leicester-city",
+      "display_name": "Leicester City",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "7bffe6af-bfd3-4a9c-b9f9-50bdf2f5a00a",
+        "88741ca0-ae4d-44d9-a40b-42d2c31d40c7",
+        "4348c26a-9b3e-45d9-8288-19ec5407d986",
+        "54f71ad3-025a-4dbc-83a7-1c665dc458fc",
+        "463959d0-f62e-4a80-a8e3-3d5ff5ed5e62"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "villarreal",
+      "display_name": "Villarreal",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "b6e53047-4615-401d-a3da-4db14fe12dce",
+        "63f2427e-2efe-408a-b1e5-1997711bba8f",
+        "27779019-c63e-4802-ad55-ae84aef20827",
+        "bacba002-688a-4fc2-b235-6a97f8baabeb",
+        "ca4cbc71-5374-4c31-a70a-61d039334cd3"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ro",
+      "display_name": "Romania",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "0efb4254-1a49-458a-ad6d-6c04083b3198",
+        "1717cf2b-a196-4ed2-88a8-d2ea447c6c1b",
+        "b3d2e72e-920a-40e4-b174-111a73d6f287",
+        "73f80ff8-0fb3-4692-987e-2dc50f911630",
+        "e0615a3d-4996-4592-b80a-f3f76db3a88a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "francesco-totti",
+      "display_name": "Francesco Totti",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "4829ee2f-5c26-45ac-82d1-e2488c70b576",
+        "ff5ff99e-982b-4737-98df-506353fa7d6a",
+        "294a3152-092b-4669-8856-fb3055607777",
+        "41dfdfa7-5beb-4bef-b64c-3f7fdb18e678",
+        "75d4b69b-04b8-4a59-a14c-f24bd79c74c1"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "dk",
+      "display_name": "Denmark",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "6f27bca6-2d37-425a-b872-d90225dca944",
+        "62998f72-4b9a-4224-940c-5302b7c39091",
+        "5b3a842e-c685-4d82-a031-243bebe23cce",
+        "1679166c-6e98-4727-861e-9421ddeee591",
+        "4a81af33-bdad-4709-876c-30ed55bd6552"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "zinedine-zidane",
+      "display_name": "Zinedine Zidane",
+      "aliases": [
+        "Zidane"
+      ],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "525ff94b-4371-4760-a517-009acee81769",
+        "11ea1b60-d2c9-49d5-8630-b2d04f736752",
+        "6d78a230-173e-401f-af70-1179b280b5c4",
+        "9332f1e8-b75d-4183-a622-15b78a8b428f",
+        "3c92266d-59c4-425e-98e8-07b02a1a9590"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "malmo-ff",
+      "display_name": "Malmö FF",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "dd2ba86e-26c8-4241-a2f5-86047e882bd1",
+        "d26ec8cb-112d-4b0c-950a-61765b4646b9",
+        "e21e482e-f1c1-4fc2-9ee6-3ebb10eb9691",
+        "37bbebae-0d6c-4710-9c5c-617ddc0711cd",
+        "3e9f79f2-3fc0-4621-b88c-c96ae993d75d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fulham",
+      "display_name": "Fulham",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "8be84f0a-07ea-4fa4-a81d-884c28efca85",
+        "4348c26a-9b3e-45d9-8288-19ec5407d986",
+        "4b3537c6-dc02-40c7-98c2-a84bfc637f3c",
+        "95e88a75-3b9e-44f5-82e8-a2977d27aa2e",
+        "463959d0-f62e-4a80-a8e3-3d5ff5ed5e62"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "river-plate",
+      "display_name": "River Plate",
+      "aliases": [
+        "Club Atlético River Plate"
+      ],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "23ffc9c5-4eb2-4e45-b108-6d92587c0863",
+        "ae438b60-b560-4147-987c-df2b0132f480",
+        "9e476a7e-7a2e-429b-820b-49cab7c434de",
+        "bc5abb52-fdd5-4cef-9d16-d52c7b8e10e2",
+        "ef3af47e-9752-4cb6-aaa1-ba283affca02"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bolton-wanderers",
+      "display_name": "Bolton Wanderers",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "5eb22262-7659-477d-910a-6d8a222b7366",
+        "b4e0d20f-0884-4b45-b159-f1a5c8605ae0",
+        "6cd47322-abd8-4d0c-8c55-dd83b77c2eb9",
+        "9ec67769-b29b-4299-bcb7-94b013e7e6cd",
+        "a200749b-8030-4ef4-91f0-31ffbf4b256c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bayer-leverkusen",
+      "display_name": "Bayer Leverkusen",
+      "aliases": [
+        "Neverkusen"
+      ],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "264efdc0-526b-4eee-b987-231f0a98344a",
+        "5816c6fe-7730-4724-a8e5-2e987c84f544",
+        "4b3537c6-dc02-40c7-98c2-a84bfc637f3c",
+        "274a5c64-e7cd-40df-9ad6-24be1e95dd4d",
+        "863cc7be-664c-43da-ad2c-4a875c634871"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "scottish-cup",
+      "display_name": "Scottish Cup",
+      "aliases": [],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "3424c5a7-4fd6-442d-8f19-bb8b0582d6b7",
+        "1d063fd6-0034-4b3c-8067-346ae4aa49b5",
+        "83c203ef-05e0-4d54-9e58-146ded79f87c",
+        "31605baa-ae78-4f02-a8c7-9e91b0afaf93",
+        "a699203b-f87d-4352-9168-753b0a9bb388"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "portugal-national-football-team",
+      "display_name": "Portugal national football team",
+      "aliases": [
+        "Portugal"
+      ],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "e160fbdd-6192-4d44-bab7-3c43b32b4700",
+        "ea9295ff-4103-4c40-adb8-dd370dc7634a",
+        "d29f2b55-2bef-4fac-99e5-25a81916a042",
+        "81a3e57d-7f44-4a6d-8fe0-0cebaa2b8908",
+        "6703ea52-3364-4661-b74d-3ea01c08043c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-schalke-04",
+      "display_name": "FC Schalke 04",
+      "aliases": [
+        "Schalke 04"
+      ],
+      "mention_count": 5,
+      "sample_question_ids": [
+        "9dcb84bf-7b47-4ba0-80bd-b080dcd583ea",
+        "ec0cbf37-5ce0-453b-b44b-5bc95d6dd6c5",
+        "16757b33-5741-4182-90d5-87d95db7991f",
+        "5816c6fe-7730-4724-a8e5-2e987c84f544",
+        "f5928327-a4e8-4f8d-a55c-d7ee01485e07"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "pele",
+      "display_name": "Pelé",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "0092b8f0-a119-48b9-b32d-5fcf365cf757",
+        "6c9883fc-7181-4a25-a2a0-598580be4b57",
+        "7e9bd199-3e87-47fc-843e-b187ba787fbc",
+        "0abeee8e-8103-4578-9d52-060274581109"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "franz-beckenbauer",
+      "display_name": "Franz Beckenbauer",
+      "aliases": [
+        "Der Kaiser"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "8076c232-b9b0-4cb7-b65c-bb012ce89cf5",
+        "e9ca6402-d177-4902-aff9-2a27dd2485a8",
+        "f727fe04-efc0-4734-a88d-764bbe1d9f14",
+        "9cf0e9a7-23e4-4491-aae9-e0cb6c34ec60"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gianluigi-buffon",
+      "display_name": "Gianluigi Buffon",
+      "aliases": [
+        "Buffon"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "eae44df1-2661-4fb1-921b-8028c317e9fa",
+        "90ce96ac-d4cc-413d-836a-cc0b9505b3e0",
+        "f6e7a26b-bf12-4344-bd92-2ce913156078",
+        "7d38ad4d-f34c-4cf9-865c-326c456b5208"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "claudio-pizarro",
+      "display_name": "Claudio Pizarro",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "305af037-445a-4175-8544-587a3170a840",
+        "7ba80b85-430c-4222-a0cc-9dec6b05b83a",
+        "0c66f399-7cb7-4c29-8657-dc474d2c574a",
+        "eca5d1f0-d4dc-470e-932d-81dd97591d1a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jack-grealish",
+      "display_name": "Jack Grealish",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "d426bb98-5e9e-494a-b5ce-83417523420f",
+        "f47c28d2-d7e8-48f0-a98c-64be231c0e90",
+        "0dc12933-b277-4a85-b056-70f3e1b6f8fc",
+        "2f635db5-78ef-449e-8069-ed432559df20"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "xabi-alonso",
+      "display_name": "Xabi Alonso",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "7d9773bf-9bfc-4520-ba6a-f324ab7b6bd9",
+        "e9f00fc1-748e-459e-91f8-49014245965c",
+        "e93ed45f-f162-4752-ba0c-c39daaf99a98",
+        "264efdc0-526b-4eee-b987-231f0a98344a"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "pep-guardiola",
+      "display_name": "Pep Guardiola",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "3b2d7862-2c05-418f-a0f1-041a8eefc41e",
+        "f47c28d2-d7e8-48f0-a98c-64be231c0e90",
+        "11f28ed9-05ec-4ff7-8f8b-6ce4aa53e1ff",
+        "18c95539-388b-4b54-b278-28e4f92efa74"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "mexico",
+      "display_name": "Mexico",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "7f9bc667-a36d-4b96-b715-8c885bf30a2b",
+        "f42de32d-8cbe-4202-8cb4-b4353114df90",
+        "df88200d-2edc-4db7-9e9c-3de7ff79f668",
+        "020faf1d-cdb6-482b-815f-cb0ff0d8be68"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "steven-gerrard",
+      "display_name": "Steven Gerrard",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "69cbfcfc-a205-4d40-8f78-60b3179ac81d",
+        "50bb9823-a00e-47cc-847f-6469da022f65",
+        "1f86d388-5c41-4517-930e-31f4eb3f426e",
+        "99749f8b-1e03-408f-9e26-f93d2323b6d4"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "boca-juniors",
+      "display_name": "Boca Juniors",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "08be2a6a-61c6-48f5-a103-4a3caa85ace6",
+        "dd540254-3125-4995-aee9-04ea352d09f1",
+        "bf9df7dd-bc40-41c2-a78c-a77cd7dc466d",
+        "ef3af47e-9752-4cb6-aaa1-ba283affca02"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "erling-haaland",
+      "display_name": "Erling Haaland",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "f47c28d2-d7e8-48f0-a98c-64be231c0e90",
+        "8323acaa-6e0c-4b3e-8d4c-e7eac613bfe8",
+        "07cdfdf1-70da-4f69-9844-26e3387e415c",
+        "cd3ace8d-bbad-452e-944d-5eb2f123fa62"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "brian-clough",
+      "display_name": "Brian Clough",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "6f145f2b-e46d-457c-8530-46db44a58c22",
+        "dd4a0dd8-65c1-4cef-957d-acbd4c81275d",
+        "d26ec8cb-112d-4b0c-950a-61765b4646b9",
+        "37bbebae-0d6c-4710-9c5c-617ddc0711cd"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "hu",
+      "display_name": "Hungary",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "598dad9d-f213-4b2d-ae74-6f431966fd98",
+        "30bea449-aacb-420e-95e8-cd0922287d88",
+        "d28c7ca0-f4bc-4bb0-8a16-cbb8aac16a74",
+        "949984af-dcee-4f36-9f71-183d353d6b22"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mohamed-salah",
+      "display_name": "Mohamed Salah",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "e0e079a8-d914-4e69-b5e8-8a1cfa7d674c",
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56",
+        "9c4dbb09-1ec2-4ab3-a120-b2177d1e03d4",
+        "2a71a58a-ed5d-436b-baa1-b5a54c22fe36"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "didier-drogba",
+      "display_name": "Didier Drogba",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "536bc997-35ec-4fd7-8fc8-a235cad0a0df",
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56",
+        "ab06ad2d-a5f7-4d0b-a4db-fc443326b612",
+        "1f02f4b5-05fd-478e-9d0b-fbf9016412b4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "thomas-muller",
+      "display_name": "Thomas Müller",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "6d41cc78-7e43-4503-a825-ad87b4d9a554",
+        "14f971f2-78ec-40e4-a5b7-5d1dc4d2433a",
+        "29311c68-029c-4446-b177-7ba2f196719e",
+        "9ce64aee-a0c4-456a-8674-b2aaf723edd4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "pavel-nedved",
+      "display_name": "Pavel Nedvěd",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "86c14847-1e8f-466a-93ed-719f5b0f02b4",
+        "ef0a0fd4-0e28-4ca2-a809-42c5e712009e",
+        "548509fb-2a94-44f2-a26a-bd40cc8179ba",
+        "7f2ce78f-b666-4c51-851e-05997d84dbe0"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "league-cup",
+      "display_name": "League Cup",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "9db8e4c5-1e00-4fdf-b2eb-f742a502f524",
+        "9204909c-8c62-4696-8aa0-9f7a9f811dc1",
+        "36bc6b0e-79a6-495e-ab45-85c845746d02",
+        "71c51fd6-4ead-46c6-aeeb-86d523a3f109"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "shakhtar-donetsk",
+      "display_name": "Shakhtar Donetsk",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "948a38d2-3117-40e6-94fe-c7a2ee083060",
+        "15fae912-1bf9-4bf2-877a-0ea9ff2c3d15",
+        "79e846be-7a22-4f08-b2e0-6155c2c05136",
+        "6ef3ad3b-77e1-45a0-bb60-0f474495aa45"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "oliver-kahn",
+      "display_name": "Oliver Kahn",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "74bd9094-4d42-4a46-9e68-907fa4d6dd12",
+        "81f4c039-d088-47f7-a180-d0463ae94e22",
+        "36432f63-f9ad-49c0-aba7-4cf28cec0c46",
+        "ab37cc87-ca19-4df9-92cd-557a9e190c13"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "dundee-united",
+      "display_name": "Dundee United",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "79df6641-152c-4c59-9bd4-ac468871d831",
+        "31605baa-ae78-4f02-a8c7-9e91b0afaf93",
+        "a699203b-f87d-4352-9168-753b0a9bb388",
+        "4c29ab5d-559a-48fc-8790-d70b4d72f50b"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "camp-nou",
+      "display_name": "Camp Nou",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "336db2d7-9273-4dd7-8d8e-d0211afa014c",
+        "a3a160ae-d78e-43ef-8f04-ccd17aa003aa",
+        "636b7294-92f4-4972-ac10-119ec9aa297d",
+        "23540058-c46d-4303-9689-ee72a9f7fe58"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dwight-yorke",
+      "display_name": "Dwight Yorke",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "94855a13-1a9c-4c37-a81b-300cae4a1b3d",
+        "606788f6-871f-4796-adcb-5e406a362a83",
+        "982b45aa-ef8f-4943-9519-31def850df15",
+        "a0deb2f9-b8fe-45f4-8206-374379f3bde0"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "de-kuip",
+      "display_name": "De Kuip",
+      "aliases": [
+        "Stadion Feijenoord"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "d55c5cb0-ec13-4cbc-82b0-427c112fdb8a",
+        "125511a3-8f77-4098-9ba7-2b8594fdba14",
+        "af771ac2-5da0-4f69-97ca-0eec1931ef63",
+        "17c68798-3be4-4c79-946d-063837487651"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "belgium",
+      "display_name": "Belgium",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "06cf25e0-df55-4041-b5e2-6103ed6a4026",
+        "cda188ca-0f9d-4fe8-a961-b73815e9173e",
+        "d85fe0ed-e0c7-42bc-8ed9-7bc1ccb3a916",
+        "24a149fb-a7c4-4154-b0cf-3a1c13e5488f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "harry-kane",
+      "display_name": "Harry Kane",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "8331cded-7f0a-4fe1-86d0-9c08f22d152d",
+        "2ca2126e-d2bd-476f-b2ce-b832f96346e4",
+        "b1ebe751-d971-4c6a-9124-7e34c64238e2",
+        "61cd15c4-cad8-43a2-bc20-f1bf6bfe5095"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "rams-park",
+      "display_name": "Rams Park",
+      "aliases": [
+        "Türk Telekom Stadium"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "f851503c-07fb-4dc3-abd5-04df26cffeb3",
+        "7d7befa8-482a-42cb-abf8-299f72486cd1",
+        "fc1aecd2-6c52-4b04-951e-6a9d23f70f36",
+        "456fe693-e58c-45d5-827c-431a9a9d13ec"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "steaua-bucuresti",
+      "display_name": "Steaua București",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "83a5defc-8396-4c75-9b4c-184b79cc47b4",
+        "58d1a666-9cba-45ee-9d98-f9065a7aaefd",
+        "7864ef8e-bb0f-47e6-8696-a0290515deaf",
+        "73ae8e46-af8c-47b8-99f7-f5ea5d3b3318"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "heart-of-midlothian",
+      "display_name": "Heart of Midlothian",
+      "aliases": [
+        "Heart of Midlothian F.C.",
+        "Hearts"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "c88aaab9-0ecd-4cb8-a055-917434735af7",
+        "14939893-6b5d-4c7a-9b5e-2717745ba327",
+        "34db4e5f-2c0d-4c4d-9e68-3c22289ee661",
+        "3424c5a7-4fd6-442d-8f19-bb8b0582d6b7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "diego-forlan",
+      "display_name": "Diego Forlán",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "fc690507-1ed5-4a42-8386-b1a06da7e729",
+        "74d0d6bd-43ce-4a3a-877e-83737a1a2567",
+        "bacba002-688a-4fc2-b235-6a97f8baabeb",
+        "ca4cbc71-5374-4c31-a70a-61d039334cd3"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "portsmouth",
+      "display_name": "Portsmouth",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "2c0769a9-08fa-4930-9d45-3bc934ae6200",
+        "50f6b87e-24f8-4e45-9aa0-5598529b5d0a",
+        "d7e97156-c840-459a-933a-7737ebda28aa",
+        "88ff0fe5-a128-4a16-8460-882e317771b9"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "mx",
+      "display_name": "Mexico",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "9a9ad507-4909-4747-937a-01ac3e0dbc9d",
+        "3ecb6bdd-df8b-46eb-aae2-57d4fd1e8cfc",
+        "bb00f629-5d8f-42ed-ab8c-3d657c66638b",
+        "7c02049b-aa08-41d7-acaf-630cfc56a480"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kevin-de-bruyne",
+      "display_name": "Kevin De Bruyne",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "739992fa-7844-4af2-bfd1-86057a6ebb7c",
+        "6498edd0-64fb-4608-a9c5-181419073ead",
+        "cd3ace8d-bbad-452e-944d-5eb2f123fa62",
+        "6aec5c73-bbcc-4d75-b97c-a7eabd70ba9a"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "cz",
+      "display_name": "Czech Republic",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "4615cc8d-518b-4550-b837-55f046469f6d",
+        "5bbbe260-c09e-4b14-adc5-c8c64d5b550f",
+        "88da5fba-9bff-40f0-a40c-9b92d370243a",
+        "160445c8-e54e-4dae-9716-3cd766e12a61"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "knvb-cup",
+      "display_name": "KNVB Cup",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "f03fdd1c-a37a-4c3a-a51e-1d7d54d42cd3",
+        "af771ac2-5da0-4f69-97ca-0eec1931ef63",
+        "f21e6ed0-1de0-4317-96d0-2c38891e31e9",
+        "ca0d5fcc-776c-46bb-ba48-7cfff08964ae"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "karim-benzema",
+      "display_name": "Karim Benzema",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "286bda23-a3bb-41e5-af0c-c1af49d359b5",
+        "d4e99e9f-adbc-4b31-9fc7-4df1695d2a21",
+        "6c2613b8-46b1-442a-8ce0-4310cd201240",
+        "b2a2012e-28a3-4298-b5e4-656366222a0b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "radamel-falcao",
+      "display_name": "Radamel Falcao",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "ec79700b-3034-4f93-9ad7-49eb4d927691",
+        "b3d2e72e-920a-40e4-b174-111a73d6f287",
+        "87200de5-1efb-4b90-ab3c-793073542d97",
+        "a27ca78b-fbb3-4e19-90dd-875cf9567178"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dimitar-berbatov",
+      "display_name": "Dimitar Berbatov",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "4b3537c6-dc02-40c7-98c2-a84bfc637f3c",
+        "6f660e57-b042-44b9-92af-75d12b13812d",
+        "274a5c64-e7cd-40df-9ad6-24be1e95dd4d",
+        "74de72dd-01d6-42fa-8f67-67ae5c1d7a78"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-da-luz",
+      "display_name": "Estádio da Luz",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "b31d9b3a-3e3d-4484-99a8-4e16362aa346",
+        "5a7126a5-ab19-4b34-94d0-bfd3dea08998",
+        "12e569f2-f572-4b35-ab49-7990762e0590",
+        "df8881c7-e522-427e-a3ac-cdd7155460f8"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ferencvarosi-tc",
+      "display_name": "Ferencvárosi TC",
+      "aliases": [],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "598dad9d-f213-4b2d-ae74-6f431966fd98",
+        "30bea449-aacb-420e-95e8-cd0922287d88",
+        "d28c7ca0-f4bc-4bb0-8a16-cbb8aac16a74",
+        "a86dcbff-a4b7-446c-b0ff-6292542ccaba"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "england-national-football-team",
+      "display_name": "England national football team",
+      "aliases": [
+        "England"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "2ca2126e-d2bd-476f-b2ce-b832f96346e4",
+        "d60a9b2b-9f7e-497d-b9c1-c2d98530a178",
+        "edcc13a2-822a-494f-a3d5-6387ac270e1b",
+        "b1ebe751-d971-4c6a-9124-7e34c64238e2"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "charlton-athletic",
+      "display_name": "Charlton Athletic",
+      "aliases": [
+        "Charlton"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "50f07e19-b233-4eb1-a323-d8903321d343",
+        "f90c36fb-96be-4581-a8a1-469c7ddd2b14",
+        "b86e786d-727c-4d35-a763-30df6b8ffd20",
+        "1c8c5755-262e-4013-adcd-ac5612e6dd63"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "croatia-national-team",
+      "display_name": "Croatia",
+      "aliases": [
+        "Croatia national team"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "2091d434-a9cd-45d1-acfc-3f7d4a5a61b7",
+        "397dc9a4-b161-47f7-b0ac-9ce5daf1f432",
+        "c94941da-a872-41c8-ad55-5cd5511db8e3",
+        "6ef3ad3b-77e1-45a0-bb60-0f474495aa45"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "rcd-espanyol",
+      "display_name": "RCD Espanyol",
+      "aliases": [
+        "Espanyol"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "dfc8d044-af9b-44fe-a0de-dd27df0f0afc",
+        "8b5f620c-2f0c-41fe-b0d7-a2188759f99c",
+        "1f8d9f36-f424-474e-938b-fedcb2822d5c",
+        "9135a2d7-c2c4-4621-b700-4d60eeb50037"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "uruguay-national-football-team",
+      "display_name": "Uruguay national football team",
+      "aliases": [
+        "Uruguay"
+      ],
+      "mention_count": 4,
+      "sample_question_ids": [
+        "2a03c7b3-fdc1-4b48-b94e-c1c4e859fa9e",
+        "607820bb-b1ad-4b50-b2c3-9df46700ca93",
+        "9b4e02bc-b1bd-4430-ba59-d27968440ac3",
+        "338d0e0e-2272-4a96-85ef-a081f71f9874"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-super-cup",
+      "display_name": "UEFA Super Cup",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "fb3711a2-1dde-43d1-a9fe-423b83f1903f",
+        "17ff02a0-c21f-453a-b641-8c5df0737994",
+        "87200de5-1efb-4b90-ab3c-793073542d97"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "bolo-zenden",
+      "display_name": "Bolo Zenden",
+      "aliases": [
+        "Boudewijn Zenden"
+      ],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "d1b12993-7530-4f83-b8c9-c94b3d0d96aa",
+        "9db8e4c5-1e00-4fdf-b2eb-f742a502f524",
+        "17ff02a0-c21f-453a-b641-8c5df0737994"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "paolo-maldini",
+      "display_name": "Paolo Maldini",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "94d4c673-224b-48d6-b831-9f37bf84d160",
+        "dede2ed1-b458-4378-af05-3f8d0f7d6a0c",
+        "48f6544e-7269-47db-a963-1d2718631298"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "erik-ten-hag",
+      "display_name": "Erik ten Hag",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "d426bb98-5e9e-494a-b5ce-83417523420f",
+        "1baf8a03-75bf-4003-9d21-f69a01d9d078",
+        "9aa9f2d4-1d4c-4174-8c02-97da793b0482"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "coupe-de-france",
+      "display_name": "Coupe de France",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "c916fcaa-31c3-4807-a486-a4b8606cad71",
+        "fbed23b4-f4e0-476d-9884-079dc1b6a7d8",
+        "ae0b9575-c8f1-4575-9f14-c7ba2556c573"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "la-galaxy",
+      "display_name": "LA Galaxy",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "69cbfcfc-a205-4d40-8f78-60b3179ac81d",
+        "ef356a96-de00-4424-b193-e65e625fcfe0",
+        "858d53c4-ee5d-4ec7-90f7-24db20b8ffa2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gabriel-batistuta",
+      "display_name": "Gabriel Batistuta",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "45ec50c2-f636-47fa-b85a-a95d0a6ad784",
+        "3b498b3f-8dee-42cc-8c39-86b072eafa41",
+        "dc90203a-f9da-4f87-afaf-a573b54128d7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "samuel-etoo",
+      "display_name": "Samuel Eto'o",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56",
+        "bb6a4db3-5e84-468c-8462-c67b06c88988",
+        "89557f60-a389-49a6-b2a4-0f91809bcf6e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "roberto-carlos",
+      "display_name": "Roberto Carlos",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "b2c07c4b-2bad-4a45-8121-60a8bd9e903a",
+        "446ceb12-5afd-4592-b97d-e06c25850794",
+        "80002466-a961-4c84-8d90-868ac327f807"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "carlos-valderrama",
+      "display_name": "Carlos Valderrama",
+      "aliases": [
+        "Valderrama"
+      ],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "14296609-97ec-4a88-be1f-6341e60dcb71",
+        "8b29f3f8-5ce6-4aea-80ca-8874bb89fc43",
+        "8f6f4285-34c5-41fa-a510-14c68a88399d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "montpellier",
+      "display_name": "Montpellier",
+      "aliases": [
+        "Montpellier HSC"
+      ],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "14296609-97ec-4a88-be1f-6341e60dcb71",
+        "c8317df9-8447-44a6-ac7a-461009429bb7",
+        "8b29f3f8-5ce6-4aea-80ca-8874bb89fc43"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "bg",
+      "display_name": "Bulgaria",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "8b23f84d-47ef-4976-9730-5432fab191e2",
+        "a0372a1b-a321-46ce-9399-95e07a35817e",
+        "274a5c64-e7cd-40df-9ad6-24be1e95dd4d"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "karaiskakis-stadium",
+      "display_name": "Karaiskakis Stadium",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "891b7d27-2a8a-480d-bd64-c5cc7e49ad2e",
+        "37cee321-f8f1-4ff6-aa8d-094aca28aee6",
+        "841dc9b3-4cd2-4050-baf1-c1870ca08155"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "eintracht-frankfurt",
+      "display_name": "Eintracht Frankfurt",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "18acd94a-03ee-4bb1-9c90-c16a6166823d",
+        "a200749b-8030-4ef4-91f0-31ffbf4b256c",
+        "f78b8365-43eb-4197-a174-407be922ef88"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "christian-vieri",
+      "display_name": "Christian Vieri",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "ef0a0fd4-0e28-4ca2-a809-42c5e712009e",
+        "548509fb-2a94-44f2-a26a-bd40cc8179ba",
+        "2a1ec7cf-555e-4207-b70b-67ac3d8f6fe4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "peter-crouch",
+      "display_name": "Peter Crouch",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "b4d4d8ba-4aae-4e50-bc26-53cb3d7cd85d",
+        "d4b58238-2795-4ad6-8202-0fc6052e4e5d",
+        "88ff0fe5-a128-4a16-8460-882e317771b9"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "stoke-city",
+      "display_name": "Stoke City",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "b4d4d8ba-4aae-4e50-bc26-53cb3d7cd85d",
+        "bd14053d-c80f-4d6f-b7a7-72f65a7eb080",
+        "d4b58238-2795-4ad6-8202-0fc6052e4e5d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "fabrizio-ravanelli",
+      "display_name": "Fabrizio Ravanelli",
+      "aliases": [
+        "The White Feather"
+      ],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "90410a42-a8fd-496e-bbbd-9b04a8e5d256",
+        "89675e1a-fa3d-4e1a-a2e3-aa394897387a",
+        "fc19abf1-fb46-4ed9-afd5-1e0089041c46"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "coupe-de-la-ligue",
+      "display_name": "Coupe de la Ligue",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "e64162d5-b170-4671-9abf-3245db9e0bd0",
+        "2126122c-6781-4891-b855-8a3a8a0a69fd",
+        "22eed7b2-a23b-49a2-8bc2-368dfe05efc1"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kylian-mbappe",
+      "display_name": "Kylian Mbappé",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "14f971f2-78ec-40e4-a5b7-5d1dc4d2433a",
+        "2126122c-6781-4891-b855-8a3a8a0a69fd",
+        "d3c63983-71b0-425b-a84c-7f453fb5914c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "rapid-wien",
+      "display_name": "Rapid Wien",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "2edc1b10-b7ed-42d1-bfa9-4cc48c2d2af3",
+        "fedef61f-b296-4626-8267-dbbfd48fdade",
+        "fbebac3b-75a0-434f-a4bb-84338719e6b5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "miroslav-klose",
+      "display_name": "Miroslav Klose",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "387f6134-cecf-46b7-b06f-b6f35a07b1d4",
+        "23c5e8e3-cb64-47b4-9c0c-6b3c41fa48f4",
+        "228f37de-aafb-4e26-a9cc-208a4c75afbe"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "henrik-larsson",
+      "display_name": "Henrik Larsson",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "1f8a9d4d-9b8a-4344-9be0-81b5c0cae714",
+        "9dd5f454-e3aa-4d26-a35c-65c00cb58e00",
+        "269c5544-7f4f-4aed-a88e-12b751b081f5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jermain-defoe",
+      "display_name": "Jermain Defoe",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "2c0769a9-08fa-4930-9d45-3bc934ae6200",
+        "50f6b87e-24f8-4e45-9aa0-5598529b5d0a",
+        "ca1e0308-df2f-4615-82ee-7a9248e48307"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "wayne-rooney",
+      "display_name": "Wayne Rooney",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "5a4fe639-4f5d-4c95-8ede-4966de5b4b6d",
+        "739992fa-7844-4af2-bfd1-86057a6ebb7c",
+        "b1ebe751-d971-4c6a-9124-7e34c64238e2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "patrick-kluivert",
+      "display_name": "Patrick Kluivert",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "f05b93b6-45e4-4753-abf4-3930a89828c0",
+        "142ff231-c192-4d1b-a735-03044f27a7a5",
+        "27b6ee4e-d7c7-4895-8e2a-15aa52c56fb6"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "paul-pogba",
+      "display_name": "Paul Pogba",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "8323acaa-6e0c-4b3e-8d4c-e7eac613bfe8",
+        "83495ea3-0eee-4193-903d-27b83382e2bc",
+        "4883be5b-7dfe-4026-bdc8-991439c2829f"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "guus-hiddink",
+      "display_name": "Guus Hiddink",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "2f5fcab3-99e9-4579-991a-607b000937d3",
+        "f2d8b1ee-d4ea-442f-861f-d13eb35b5494",
+        "65497f46-8590-4ca3-8a42-89c50857ba93"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "co",
+      "display_name": "Colombia",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "8b29f3f8-5ce6-4aea-80ca-8874bb89fc43",
+        "35707a7c-d5f7-4a62-a3c9-44de1e1025c6",
+        "9e476a7e-7a2e-429b-820b-49cab7c434de"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "lokomotive-leipzig",
+      "display_name": "Lokomotive Leipzig",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "72276ea9-28d0-447e-9cf6-36c7963fb9b6",
+        "5d3bce29-95ea-477b-979c-8ce7a45ddd5c",
+        "4cce8ee3-4864-4a7a-b393-a5e63b4571e0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marco-van-basten",
+      "display_name": "Marco van Basten",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "72276ea9-28d0-447e-9cf6-36c7963fb9b6",
+        "5d3bce29-95ea-477b-979c-8ce7a45ddd5c",
+        "4cce8ee3-4864-4a7a-b393-a5e63b4571e0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "fernando-torres",
+      "display_name": "Fernando Torres",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "a303e331-55c3-460e-8348-28d16f69c77e",
+        "9aa36877-73ed-4bb2-9a62-048e024538d1",
+        "7a688c9c-dbdb-4c9b-8348-76ab0c3d8fe7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "diego-milito",
+      "display_name": "Diego Milito",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "27bcaa20-0365-46f5-9244-a150c6c7d1f9",
+        "caf5122a-d21e-451b-9910-d8729e949098",
+        "0659d08d-cdda-4bf0-9e0b-361aec0ec83e"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "yu",
+      "display_name": "Yugoslavia",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "62998f72-4b9a-4224-940c-5302b7c39091",
+        "da79819b-62df-4854-8996-d0e66c29fb3b",
+        "32a685a2-4891-4705-b3ce-21811cf0ef1f"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ec",
+      "display_name": "Ecuador",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "e745d683-f78f-40b3-ae15-657a4db34324",
+        "34ab5bcf-313a-4117-9ec2-35962fa4d8e8",
+        "a665e682-0be3-40e8-8059-87f560b1c4cc"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-twente",
+      "display_name": "FC Twente",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "ceeb7aba-4290-41ca-a77c-34322e84198a",
+        "6fb5d47c-dc34-4a5c-8234-b5cc2a239a95",
+        "9f496f34-24e9-42ba-98b5-fb2ff26b14ac"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "olympiastadion-munich",
+      "display_name": "Olympiastadion in Munich",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "edcc13a2-822a-494f-a3d5-6387ac270e1b",
+        "c8bcde11-88d9-4068-8f22-12430437786b",
+        "d4fc0d78-15b6-41d9-9b2c-b30c17e75016"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "angelos-charisteas",
+      "display_name": "Angelos Charisteas",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "6703ea52-3364-4661-b74d-3ea01c08043c",
+        "fe6fb11e-7d1b-4646-89ec-40d433aa27db",
+        "ea9295ff-4103-4c40-adb8-dd370dc7634a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mesut-ozil",
+      "display_name": "Mesut Özil",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "6498edd0-64fb-4608-a9c5-181419073ead",
+        "9595ac2b-27c8-41c0-9776-9dd739b642e4",
+        "771d2568-6295-45dc-acd0-7d64d7a10e9c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gary-lineker",
+      "display_name": "Gary Lineker",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "b1ebe751-d971-4c6a-9124-7e34c64238e2",
+        "e2d0c76d-e401-4c3d-aaac-811e29c73973",
+        "dec4e28b-43cd-4209-b3be-c0bbcbd41874"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "antonin-panenka",
+      "display_name": "Antonín Panenka",
+      "aliases": [
+        "Panenka"
+      ],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "82cad305-c0c9-4219-a11e-b5eb6b9f81c7",
+        "88da5fba-9bff-40f0-a40c-9b92d370243a",
+        "affbc016-d07d-453b-bf71-2b3de3223cb1"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "david-beckham",
+      "display_name": "David Beckham",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "1a866c5c-db5b-4453-9d44-f15c0bf0fd83",
+        "f5b7b767-55b6-4a57-83a1-53631321b822",
+        "99749f8b-1e03-408f-9e26-f93d2323b6d4"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "deportivo-la-coruna",
+      "display_name": "Deportivo La Coruña",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "1fdd4f9d-821b-41ed-8acf-ccefe698ae8d",
+        "2b0aa20b-7f27-4468-aab2-65d0c744c918",
+        "f84745bd-de92-42bd-89e0-8b990ae6bdf4"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "sa",
+      "display_name": "Saudi Arabia",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "72331454-7bfa-486d-ab7d-31bd8d8c55ca",
+        "a2ecf71e-5fa9-4dcc-99dc-1268e25eaa18",
+        "755c8ec6-7a48-418b-9a70-cd9de97ae8f0"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "anderlecht",
+      "display_name": "Anderlecht",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "6b6f269c-95b4-4a89-bf3c-3dcb4814fa06",
+        "696ef1fe-28ad-4163-a872-ff9b46fc66a5",
+        "ea992160-bf3f-487e-ac67-990b7c9f4505"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "just-fontaine",
+      "display_name": "Just Fontaine",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "8b4479e1-59cb-4836-a34e-4caa328637f9",
+        "ae0b9575-c8f1-4575-9f14-c7ba2556c573",
+        "23c5e8e3-cb64-47b4-9c0c-6b3c41fa48f4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ousmane-dembele",
+      "display_name": "Ousmane Dembélé",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "d3c63983-71b0-425b-a84c-7f453fb5914c",
+        "58a3faba-8b46-407b-bf8b-1ba9e2d8ff2e",
+        "f78b8365-43eb-4197-a174-407be922ef88"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dirk-kuyt",
+      "display_name": "Dirk Kuyt",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "86a53d23-13fc-439e-b380-1545c2c43729",
+        "6893e81b-0acf-402b-a918-09acb9be4777",
+        "fe22e6c8-75b1-4780-8c96-127bbf75865b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marek-hamsik",
+      "display_name": "Marek Hamšík",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "834a055d-8ec2-42e0-af1b-035d2edc7b77",
+        "d15cfd21-5e91-4e9d-8d53-fc3fbd9a6e5a",
+        "daa62a72-1807-4a4a-bf32-77bf830d91e0"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadio-olimpico",
+      "display_name": "Stadio Olimpico",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "5a6fb4a6-32c9-439e-9953-0aa3250d3b3b",
+        "f0e27fea-3313-4017-85ea-2dc25ccb0bdf",
+        "77f12ea2-14ca-4a35-9097-3f4f9d9ebba3"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "johan-cruyff-arena",
+      "display_name": "Johan Cruyff Arena",
+      "aliases": [
+        "Amsterdam Arena",
+        "Amsterdam ArenA"
+      ],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "e320c520-5e88-4088-ab2a-d7a6f6374d16",
+        "8848d2ee-f703-45fa-8251-f0f615aa0941",
+        "bc4cc5bb-136e-4569-894c-4d9d96e6166d"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "massimiliano-allegri",
+      "display_name": "Massimiliano Allegri",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "27fe0d2f-1bc3-46a4-8e8c-dd9d9457a890",
+        "89ce432b-9538-46c6-b6fc-3f6fc0e506bc",
+        "05d81d8f-ad2a-4e35-97c3-04bdc0074809"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "european-golden-shoe",
+      "display_name": "European Golden Shoe",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "3d74ad2a-bec3-43b6-a155-ac9bf60b1f27",
+        "d2a7c41b-a41a-4d29-84f0-ec51e386ecbf",
+        "74d0d6bd-43ce-4a3a-877e-83737a1a2567"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ifk-goteborg",
+      "display_name": "IFK Göteborg",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "dcea392f-1ddf-490c-8dc3-60f49216f551",
+        "54d3dcf9-8542-4892-856c-9d4f136c6c61",
+        "4c29ab5d-559a-48fc-8790-d70b4d72f50b"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "at",
+      "display_name": "Austria",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "3cb7579f-944f-4239-a897-966b030dfd10",
+        "f72d2475-f1e2-4424-a8b8-8ad9f29c4aae",
+        "15d25ac5-1dad-478a-b522-9c3cb224f54f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "wolverhampton-wanderers",
+      "display_name": "Wolverhampton Wanderers",
+      "aliases": [
+        "Wolves"
+      ],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "f90c36fb-96be-4581-a8a1-469c7ddd2b14",
+        "4db65797-8613-4d71-81e7-fd1272541843",
+        "b86e786d-727c-4d35-a763-30df6b8ffd20"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "besiktas-jk",
+      "display_name": "Beşiktaş JK",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "96dc7442-28d3-46a4-bdae-9e01941de36f",
+        "c00998be-be89-47c4-b14f-7506e4e4d165",
+        "68b6c454-4587-443b-af51-3f68e524d396"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "club-brugge-kv",
+      "display_name": "Club Brugge KV",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "1125de01-6cb9-4b10-afa8-a8be369c204b",
+        "5a47661b-b83b-4cf1-9241-9cee351493a4",
+        "da983271-dbc2-43dc-b95a-506687f82ebc"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "european-golden-boot",
+      "display_name": "European Golden Boot",
+      "aliases": [
+        "Golden Boot"
+      ],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "2b0d4974-ed1a-4b1c-a826-9b59dbad80fd",
+        "397dc9a4-b161-47f7-b0ac-9ce5daf1f432",
+        "1f8a9d4d-9b8a-4344-9be0-81b5c0cae714"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "olympiastadion-berlin",
+      "display_name": "Olympiastadion",
+      "aliases": [],
+      "mention_count": 3,
+      "sample_question_ids": [
+        "526b779f-fbc6-40f1-8468-c1e0302eafc1",
+        "10f22af6-d66c-4e97-9abd-933edf6d8791",
+        "5816c6fe-7730-4724-a8e5-2e987c84f544"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "getafe",
+      "display_name": "Getafe",
+      "aliases": [
+        "Getafe CF"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "b7e52a06-ad42-4e23-8cb1-6b82e9454069",
+        "474c5d85-389e-40cd-a3cb-199fb3355565"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "olympique-de-marseille",
+      "display_name": "Olympique de Marseille",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "84f6e2b4-42c3-492b-a599-8907b539a789",
+        "85a1a10d-fdfa-4478-9d9b-5b0ac03b276d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "santos",
+      "display_name": "Santos",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "0092b8f0-a119-48b9-b32d-5fcf365cf757",
+        "e1e00d14-9b4c-4518-95cc-6a3f51472e62"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "hristo-stoichkov",
+      "display_name": "Hristo Stoichkov",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a140ee10-bdc4-42a2-8e9c-388b30563854",
+        "a0372a1b-a321-46ce-9399-95e07a35817e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "oleg-blokhin",
+      "display_name": "Oleg Blokhin",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a86dcbff-a4b7-446c-b0ff-6292542ccaba",
+        "87200de5-1efb-4b90-ab3c-793073542d97"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alfredo-di-stefano",
+      "display_name": "Alfredo Di Stéfano",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "5a1ad6b9-962f-455b-8c89-eb776d5b7186",
+        "de1b03e8-bb7c-46d2-ab87-bd3069560ba9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "franz-roth",
+      "display_name": "Franz Roth",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "e9ca6402-d177-4902-aff9-2a27dd2485a8",
+        "ea66a753-6dc7-4ed3-ad2e-a4c12474cda2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "lucas-moura",
+      "display_name": "Lucas Moura",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "f4fb5b28-0dfa-477d-849f-2ca1a5b6922a",
+        "4f9fe72e-0220-44e3-9ed7-c568cd81dbb1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bordeaux",
+      "display_name": "Bordeaux",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "85a1a10d-fdfa-4478-9d9b-5b0ac03b276d",
+        "22eed7b2-a23b-49a2-8bc2-368dfe05efc1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sheffield-united",
+      "display_name": "Sheffield United",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "4c9120ee-de05-495a-bc19-fa3f84433345",
+        "dfcb2fc6-9657-4b7d-b8e0-ca0cdadcf3d3"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "ibrox-stadium",
+      "display_name": "Ibrox Stadium",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "dac066da-a6c3-418a-b9d8-71e3455530e4",
+        "24c23d14-36aa-4e94-8630-7c864a3d85b2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "uwe-seeler",
+      "display_name": "Uwe Seeler",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "28022225-0dd0-41d7-ba6e-200592cb8958",
+        "f669a9de-531a-44c8-9ec9-1755b06b263d"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadio-artemio-franchi",
+      "display_name": "Stadio Artemio Franchi",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a58d5ccd-47a4-436b-928e-74195543af30",
+        "a33e971c-f202-495a-af20-6a75666f2293"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "robin-van-persie",
+      "display_name": "Robin van Persie",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "e9f00fc1-748e-459e-91f8-49014245965c",
+        "a7a3aa51-ade9-4c7d-883d-69e050620268"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "arjen-robben",
+      "display_name": "Arjen Robben",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "e9f00fc1-748e-459e-91f8-49014245965c",
+        "cdd7ab12-287e-4809-8a32-4d9f54a53937"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "queens-park-rangers",
+      "display_name": "Queens Park Rangers",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "fb882f56-7414-44c9-b9d3-e9963bde62db",
+        "8c43d69f-719c-42ac-98f2-64a45b971e68"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "zinedine-zidane",
+      "display_name": "Zinedine Zidane",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "b08f7569-13e5-4bf1-a92d-519285814af6",
+        "086e9f68-c7dc-4981-be54-24264b609794"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "bora-milutinovic",
+      "display_name": "Bora Milutinović",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "7f9bc667-a36d-4b96-b715-8c885bf30a2b",
+        "f42de32d-8cbe-4202-8cb4-b4353114df90"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gheorghe-hagi",
+      "display_name": "Gheorghe Hagi",
+      "aliases": [
+        "Maradona of the Carpathians",
+        "The Maradona of the Carpathians"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "c43bbec4-e7e3-4d70-90ac-b466ea2b6584",
+        "3aeb6565-6863-4751-a806-ea224fb77ccc"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "romania",
+      "display_name": "Romania",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "c43bbec4-e7e3-4d70-90ac-b466ea2b6584",
+        "3aeb6565-6863-4751-a806-ea224fb77ccc"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "copa-libertadores",
+      "display_name": "Copa Libertadores",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "08be2a6a-61c6-48f5-a103-4a3caa85ace6",
+        "2f78c9ca-0ce3-48a7-9436-145f06d43741"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "giovanni-trapattoni",
+      "display_name": "Giovanni Trapattoni",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a581005f-8459-4d4d-8e19-6e079e6edc06",
+        "63f2427e-2efe-408a-b1e5-1997711bba8f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "shay-given",
+      "display_name": "Shay Given",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "5afee0a8-6bd9-4bab-92a3-3d09f755a195",
+        "32824002-544c-4e1c-9ed4-7a4aca195878"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "roberto-baggio",
+      "display_name": "Roberto Baggio",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "c90d918a-42e4-4c24-81e5-98803cb90423",
+        "20f54c0e-8a12-4185-b3e5-7310af6cbb59"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gerard-pique",
+      "display_name": "Gerard Pique",
+      "aliases": [
+        "Gerard Piqué"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "03d3e0d2-0ac1-4ab0-95b9-87a4f1a78982",
+        "00d3f86a-3592-40be-9381-b97572a01a8d"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "lars-lagerback",
+      "display_name": "Lars Lagerbäck",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "89232e57-a594-4a24-9221-6b830bbe2cf9",
+        "8ed6b8a0-064d-4b84-a96c-68be0054ecdf"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "africa-cup-of-nations",
+      "display_name": "Africa Cup of Nations",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56",
+        "2c50ebd0-ef75-4436-be68-ca00bede68db"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gianfranco-zola",
+      "display_name": "Gianfranco Zola",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "4447e6cb-3434-43a4-bcd5-7b24df278b97",
+        "99749f8b-1e03-408f-9e26-f93d2323b6d4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kingsley-coman",
+      "display_name": "Kingsley Coman",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "6d41cc78-7e43-4503-a825-ad87b4d9a554",
+        "29311c68-029c-4446-b177-7ba2f196719e"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "san-siro",
+      "display_name": "San Siro",
+      "aliases": [
+        "Stadio Giuseppe Meazza"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a71e279d-4bfd-460a-91cf-e4071e3061e3",
+        "323b6334-4486-4467-b6f5-53c5cef77dd5"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "trabzonspor",
+      "display_name": "Trabzonspor",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "097a3848-8bc6-44c8-969c-a7dd931d1628",
+        "96dc7442-28d3-46a4-bdae-9e01941de36f"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stamford-bridge",
+      "display_name": "Stamford Bridge",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "67c27cf6-0a78-4f5f-a768-42cfa31b7581",
+        "cacab5aa-0987-4619-a32f-ebeaa7fea514"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "parc-des-princes",
+      "display_name": "Parc des Princes",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "be2d99e9-ff64-4808-829a-bab3a93f9051",
+        "88a281d6-d639-4721-86cb-324ce4b3f0f0"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-euro-2004",
+      "display_name": "UEFA Euro 2004",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "74d8f203-ce2a-4771-98de-081cee56aa24",
+        "fd7a7d8d-17e4-4e65-8c14-b67e9b6d16eb"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jean-pierre-papin",
+      "display_name": "Jean-Pierre Papin",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "00e373bd-9099-4983-95a3-b14961a6c4f8",
+        "ae0b9575-c8f1-4575-9f14-c7ba2556c573"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "roger-milla",
+      "display_name": "Roger Milla",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "3b4f4a84-7feb-4149-ad2d-47e9e88c7a74",
+        "b15f0602-af76-4866-8021-d655884d72c2"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "torino",
+      "display_name": "Torino",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "44b50a9b-7b97-455c-b2ea-fd780f370114",
+        "19831ab4-b052-4357-ad2f-b9cc94057b98"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "brescia",
+      "display_name": "Brescia",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "3aeb6565-6863-4751-a806-ea224fb77ccc",
+        "cc5053ca-fa75-44a5-bbe9-e0061cf83562"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "taca-de-portugal",
+      "display_name": "Taça de Portugal",
+      "aliases": [
+        "Portuguese Cup"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "54aefaa6-3a28-4833-b058-708cc19854c6",
+        "889631dc-89e7-4e0a-8e6f-051b78042bb7"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "sven-goran-eriksson",
+      "display_name": "Sven-Göran Eriksson",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "508c411a-8e5e-458c-846f-843c3c80daac",
+        "dcea392f-1ddf-490c-8dc3-60f49216f551"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "rajko-mitic-stadium",
+      "display_name": "Rajko Mitić Stadium",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "ef94e1a6-9bea-4e8a-a7b9-fcfa4975f797",
+        "19076705-9a1c-406f-be7c-c738f474aa41"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "juninho-paulista",
+      "display_name": "Juninho Paulista",
+      "aliases": [
+        "Juninho"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "36bc6b0e-79a6-495e-ab45-85c845746d02",
+        "71c51fd6-4ead-46c6-aeeb-86d523a3f109"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "afc-asian-cup",
+      "display_name": "AFC Asian Cup",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "64afb3b2-c0c5-4786-b05a-bd7535fef6f5",
+        "66949d31-27ff-4458-9a6a-dbe079bc0495"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ali-daei",
+      "display_name": "Ali Daei",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "64afb3b2-c0c5-4786-b05a-bd7535fef6f5",
+        "34ab5bcf-313a-4117-9ec2-35962fa4d8e8"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "denmark",
+      "display_name": "Denmark",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "260e6cbd-d01f-4e79-a0e5-496434539ba1",
+        "ee8faddf-f31e-4169-bf1a-d9ec6cff2a75"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "yugoslavia",
+      "display_name": "Yugoslavia",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "260e6cbd-d01f-4e79-a0e5-496434539ba1",
+        "a0cb5247-f106-4786-954e-033d5d1c72ea"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "raymond-goethals",
+      "display_name": "Raymond Goethals",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "b1f39486-d40e-4864-a19b-042f990d48f9",
+        "94a349dd-56fa-40a9-843b-026fcb826e0f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "eden-hazard",
+      "display_name": "Eden Hazard",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "346a625d-7c13-4685-a973-87e63fee0a06",
+        "44e89a87-6742-4cb2-923d-bedad938e0d6"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fenerbahce-sk",
+      "display_name": "Fenerbahçe SK",
+      "aliases": [
+        "Fenerbahçe"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "64ee11d3-254b-42fd-b49e-df175574282e",
+        "68b6c454-4587-443b-af51-3f68e524d396"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "scottish-premier-league",
+      "display_name": "Scottish Premier League",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "c88aaab9-0ecd-4cb8-a055-917434735af7",
+        "a1c1a80e-1c1d-4497-ae5c-1c3429421403"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "scottish-premiership",
+      "display_name": "Scottish Premiership",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "c88aaab9-0ecd-4cb8-a055-917434735af7",
+        "ce91e532-d78c-480e-a58c-9e609f59af0a"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "allianz-arena",
+      "display_name": "Allianz Arena",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "14f971f2-78ec-40e4-a5b7-5d1dc4d2433a",
+        "930f143f-a516-479c-ade4-fd9ec5b519af"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "campeonato-brasileiro-serie-a",
+      "display_name": "Campeonato Brasileiro Série A",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "7aa22b79-e956-4ad7-b366-fc97a4ea21aa",
+        "125badf2-fd52-4221-b6d5-47351132e69f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "miranda",
+      "display_name": "Miranda",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "5b8361a2-7bd0-40dc-9a34-f94c8e1b51e7",
+        "0de86b5f-3aba-4b02-80cc-2be497af288f"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-jose-alvalade",
+      "display_name": "Estádio José Alvalade",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a24c4a67-6385-4354-83ae-6c8ebb7d7989",
+        "4193ae6f-2295-4327-bbcc-a3d4887505ec"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "carlton-cole",
+      "display_name": "Carlton Cole",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "b86e786d-727c-4d35-a763-30df6b8ffd20",
+        "f90c36fb-96be-4581-a8a1-469c7ddd2b14"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "anfield",
+      "display_name": "Anfield",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "f5aeb639-eae1-4885-9980-39fed8a6d8f0",
+        "15e74acd-4435-43e4-a7b4-11487e0bf8b7"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bournemouth",
+      "display_name": "Bournemouth",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "2c0769a9-08fa-4930-9d45-3bc934ae6200",
+        "9aa9f2d4-1d4c-4174-8c02-97da793b0482"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jamie-carragher",
+      "display_name": "Jamie Carragher",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "50bb9823-a00e-47cc-847f-6469da022f65",
+        "ec6a060a-f194-4c09-9527-0ae8e2a1af39"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "cy",
+      "display_name": "Cyprus",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a88746d1-3b34-4a4d-ba4d-0223621c2174",
+        "1c77b380-5c99-4615-920e-25a958aea102"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "be",
+      "display_name": "Belgium",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "01c3d610-4b3f-410d-8065-d187deecd108",
+        "1125de01-6cb9-4b10-afa8-a8be369c204b"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "brighton-hove-albion",
+      "display_name": "Brighton & Hove Albion",
+      "aliases": [
+        "Brighton"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "dd4a0dd8-65c1-4cef-957d-acbd4c81275d",
+        "7c37bb22-c0a9-45d0-831d-afa25f8d2177"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "boavista",
+      "display_name": "Boavista",
+      "aliases": [
+        "Boavista F.C."
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "72791ad2-552e-4351-a4d0-04bbe51b2482",
+        "f8d4b6b4-72c1-45a2-964a-f3ce588364a4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ryan-giggs",
+      "display_name": "Ryan Giggs",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "739992fa-7844-4af2-bfd1-86057a6ebb7c",
+        "2d4b0818-4569-415e-b06c-b8dda62081df"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "cesc-fabregas",
+      "display_name": "Cesc Fàbregas",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "739992fa-7844-4af2-bfd1-86057a6ebb7c",
+        "6498edd0-64fb-4608-a9c5-181419073ead"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ch",
+      "display_name": "Switzerland",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "65666bbb-884c-49a4-8835-983725de072b",
+        "ba0c8796-97a9-4a27-a081-49a31e09c91f"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "russian-premier-league",
+      "display_name": "Russian Premier League",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a4403d41-dbca-4f8f-b8e8-6dbbb4050ea7",
+        "4b10c27a-1bb0-484b-9c51-02609273af0f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "lars-ricken",
+      "display_name": "Lars Ricken",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "1d41f286-d413-4e3e-b1ff-89fbe2b765de",
+        "c11e3345-031f-4ad7-af0e-dc6c61e0d169"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "trevor-francis",
+      "display_name": "Trevor Francis",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "dd2ba86e-26c8-4241-a2f5-86047e882bd1",
+        "d26ec8cb-112d-4b0c-950a-61765b4646b9"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "philips-stadion",
+      "display_name": "Philips Stadion",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "0cd8ba2b-66da-48a2-a472-a3f5bf4089f8",
+        "4017eee8-1879-448d-a22c-bb9aa184784b"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "fifa-womens-world-cup",
+      "display_name": "FIFA Women's World Cup",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "054d075b-c648-4b91-8e1a-c31766e56055",
+        "448f19cf-5875-40f5-95e1-b681debdffdd"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "luis-suarez",
+      "display_name": "Luis Suárez",
+      "aliases": [
+        "Suárez"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "ac409224-d2dd-484e-8c2f-d5b8c4b4b5e9",
+        "06dc6ccf-f602-40c9-8908-b1a088cd48e5"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "santiago-bernabeu-stadium",
+      "display_name": "Santiago Bernabéu Stadium",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "24697004-5812-45b7-85b7-8ebbb7442eec",
+        "e7a82cb5-4e6c-4b70-8dac-56059f547c9c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "real-zaragoza",
+      "display_name": "Real Zaragoza",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "27bcaa20-0365-46f5-9244-a150c6c7d1f9",
+        "b86941de-9fd2-4eb8-9d79-f14678c40d5c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "al-ittihad",
+      "display_name": "Al-Ittihad",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "286bda23-a3bb-41e5-af0c-c1af49d359b5",
+        "83437758-5b21-44e0-b60f-448defc8c301"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "afc-champions-league",
+      "display_name": "AFC Champions League",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "286bda23-a3bb-41e5-af0c-c1af49d359b5",
+        "83437758-5b21-44e0-b60f-448defc8c301"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "basile-boli",
+      "display_name": "Basile Boli",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "91a18fdc-a3eb-43fc-89d4-c186cfafb1a8",
+        "d4fc0d78-15b6-41d9-9b2c-b30c17e75016"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-monumental-isidro-romero-carbo",
+      "display_name": "Estadio Monumental Isidro Romero Carbo",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "e745d683-f78f-40b3-ae15-657a4db34324",
+        "a665e682-0be3-40e8-8059-87f560b1c4cc"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "barcelona-sc",
+      "display_name": "Barcelona SC",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "e745d683-f78f-40b3-ae15-657a4db34324",
+        "a665e682-0be3-40e8-8059-87f560b1c4cc"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "abedi-pele",
+      "display_name": "Abedi Pele",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "eff497a5-2b4a-444e-8ef0-8ece43da102f",
+        "2e38b408-253d-4b10-80d3-4ec263d72b28"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "celtic-park",
+      "display_name": "Celtic Park",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "fbc56650-390b-4f4d-a3ea-34e7b8371473",
+        "72ec1ba3-7ef1-475a-96b5-f0bfaf6257e9"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-intertoto-cup",
+      "display_name": "UEFA Intertoto Cup",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "ceeb7aba-4290-41ca-a77c-34322e84198a",
+        "27779019-c63e-4802-ad55-ae84aef20827"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "david-trezeguet",
+      "display_name": "David Trezeguet",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "617b0c68-a5a3-4107-9f00-0434516f9e31",
+        "2989821b-a0fa-452b-8fdb-9df934c158f1"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "michael-owen",
+      "display_name": "Michael Owen",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "edcc13a2-822a-494f-a3d5-6387ac270e1b",
+        "2255d1de-cb1a-4281-9224-67200c0b8342"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "psv",
+      "display_name": "PSV",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "27b6ee4e-d7c7-4895-8e2a-15aa52c56fb6",
+        "17ff02a0-c21f-453a-b641-8c5df0737994"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "carlo-ancelotti",
+      "display_name": "Carlo Ancelotti",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "e93ed45f-f162-4752-ba0c-c39daaf99a98",
+        "73630cf2-14af-4beb-83b0-80bc754341fd"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "brad-friedel",
+      "display_name": "Brad Friedel",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "80e7ea3c-4743-4e34-b6bc-ccbcd60349c1",
+        "8f1662ff-9f8d-4f03-af74-b669ebe58f35"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "az-alkmaar",
+      "display_name": "AZ Alkmaar",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "aefd9400-0512-4470-b6bc-1d92eb998106",
+        "9766195d-0df8-48b8-bfc2-db4d1f11141e"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "bobby-robson",
+      "display_name": "Bobby Robson",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "aefd9400-0512-4470-b6bc-1d92eb998106",
+        "9766195d-0df8-48b8-bfc2-db4d1f11141e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fk-vojvodina",
+      "display_name": "FK Vojvodina",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "8bad682a-ae10-4990-b906-24568c025abd",
+        "c1cfb4c3-a7c8-4ef6-a220-88d1e7c7153d"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "karadorde-stadium",
+      "display_name": "Karađorđe Stadium",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "8bad682a-ae10-4990-b906-24568c025abd",
+        "c1cfb4c3-a7c8-4ef6-a220-88d1e7c7153d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "rogerio-ceni",
+      "display_name": "Rogério Ceni",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "d0e8d602-edb0-4c69-8354-e91f134112e1",
+        "80002466-a961-4c84-8d90-868ac327f807"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "diego-simeone",
+      "display_name": "Diego Simeone",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "63f2427e-2efe-408a-b1e5-1997711bba8f",
+        "65b98f9a-5510-4d37-9b1b-d676d4255833"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mark-viduka",
+      "display_name": "Mark Viduka",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "bd8ea8e4-2d65-4864-bdcf-ecf043d0d855",
+        "4c2a422c-4427-4fba-8986-1ae5e8ed1e43"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "sergio-aguero",
+      "display_name": "Sergio Agüero",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "d4e99e9f-adbc-4b31-9fc7-4df1695d2a21",
+        "cd3ace8d-bbad-452e-944d-5eb2f123fa62"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "helmuth-duckadam",
+      "display_name": "Helmuth Duckadam",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "58d1a666-9cba-45ee-9d98-f9065a7aaefd",
+        "73ae8e46-af8c-47b8-99f7-f5ea5d3b3318"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jimmy-greaves",
+      "display_name": "Jimmy Greaves",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "b1ebe751-d971-4c6a-9124-7e34c64238e2",
+        "2295a4e7-1d5f-43da-bace-959ecd6fc316"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "alex-ferguson",
+      "display_name": "Alex Ferguson",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "f7f638f3-4e67-448a-87f5-b0fbe6f458d5",
+        "cd491e0b-bf4e-40c3-a198-f1235fba6d56"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "michel-platini",
+      "display_name": "Michel Platini",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "ce00079f-4f75-442c-96af-11b0ecec676d",
+        "ae0b9575-c8f1-4575-9f14-c7ba2556c573"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "spartak-moscow",
+      "display_name": "Spartak Moscow",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "25687d54-4342-4532-94f5-f3b6faacaee8",
+        "4b10c27a-1bb0-484b-9c51-02609273af0f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "czechoslovakia",
+      "display_name": "Czechoslovakia",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "82cad305-c0c9-4219-a11e-b5eb6b9f81c7",
+        "affbc016-d07d-453b-bf71-2b3de3223cb1"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "manuel-neuer",
+      "display_name": "Manuel Neuer",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "201bf405-5f8d-440d-ad20-2d2ba69d0148",
+        "0245064c-e0f7-40d8-9a92-fc52cb1b0dcd"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "giuseppe-meazza",
+      "display_name": "Giuseppe Meazza",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "15f57616-cab1-49b6-b8dc-42d631279775",
+        "1246eb5b-dbb7-4065-a495-e0e6b5b6cac8"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kevin-nolan",
+      "display_name": "Kevin Nolan",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "9e14697a-16f4-4f19-a25b-5862dd6e0518",
+        "6cd47322-abd8-4d0c-8c55-dd83b77c2eb9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "george-best",
+      "display_name": "George Best",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "23cea525-3c83-4f91-bbdb-7e70945a66d5",
+        "51cc6b60-586e-4e82-a31f-3c9f4ba61832"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-mas-monumental",
+      "display_name": "Estadio Mâs Monumental",
+      "aliases": [
+        "El Monumental",
+        "Estadio Antonio Vespucio Liberti"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "ae438b60-b560-4147-987c-df2b0132f480",
+        "bc5abb52-fdd5-4cef-9d16-d52c7b8e10e2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "silvio-piola",
+      "display_name": "Silvio Piola",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "1246eb5b-dbb7-4065-a495-e0e6b5b6cac8",
+        "49f6f8f9-96b9-41f6-b40c-52cca8c93ffb"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "raheem-sterling",
+      "display_name": "Raheem Sterling",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "8a8aaab2-a1aa-4985-b924-6cb6f7ca524d",
+        "cd3ace8d-bbad-452e-944d-5eb2f123fa62"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "landon-donovan",
+      "display_name": "Landon Donovan",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "6183fbaf-70cd-4888-896e-3f88222a25dd",
+        "858d53c4-ee5d-4ec7-90f7-24db20b8ffa2"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "ernst-happel",
+      "display_name": "Ernst Happel",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "4b94d628-937f-4c93-9c96-83501604d324",
+        "c45bb399-e254-48e8-8483-816cdc0f46a1"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "robbie-keane",
+      "display_name": "Robbie Keane",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "b41d63a6-18c4-4ad3-aa56-c2e4fa6acdf5",
+        "ef356a96-de00-4424-b193-e65e625fcfe0"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-copenhagen",
+      "display_name": "FC Copenhagen",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "1679166c-6e98-4727-861e-9421ddeee591",
+        "4bc631bb-f78e-4c4b-9168-9e862db636ca"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "watford",
+      "display_name": "Watford",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "d3c5328d-2258-4868-b006-eb8d90d5926a",
+        "6bacae11-7dd0-4e40-b073-4cba8b0f8647"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "thomas-tuchel",
+      "display_name": "Thomas Tuchel",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a02d5b6b-9958-4709-8f33-f1123fdaaddc",
+        "0245064c-e0f7-40d8-9a92-fc52cb1b0dcd"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ng",
+      "display_name": "Nigeria",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "fd3c289c-eb31-4c0c-a037-58dd26a5d359",
+        "d4274cb4-056d-42c7-96a1-bcbe01b84790"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "saudi-pro-league",
+      "display_name": "Saudi Pro League",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a2ecf71e-5fa9-4dcc-99dc-1268e25eaa18",
+        "627d2930-394e-4140-b64a-2ae9f2a6315f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "philippe-coutinho",
+      "display_name": "Philippe Coutinho",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "d3c63983-71b0-425b-a84c-7f453fb5914c",
+        "5b9511ad-0018-4b27-84e4-ae6da8beea20"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "joao-felix",
+      "display_name": "João Félix",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "d3c63983-71b0-425b-a84c-7f453fb5914c",
+        "3f372638-d56b-45eb-aca2-444690340c4c"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "ange-postecoglou",
+      "display_name": "Ange Postecoglou",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "b8dd6713-1bc5-4bd2-bbf2-ef48b14a2761",
+        "95e88a75-3b9e-44f5-82e8-a2977d27aa2e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kevin-phillips",
+      "display_name": "Kevin Phillips",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "41a00928-46a3-455a-a963-da7481bd0a5e",
+        "d2a7c41b-a41a-4d29-84f0-ec51e386ecbf"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "eusebio",
+      "display_name": "Eusebio",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "2b0d4974-ed1a-4b1c-a826-9b59dbad80fd",
+        "889631dc-89e7-4e0a-8e6f-051b78042bb7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "roy-makaay",
+      "display_name": "Roy Makaay",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "2b0aa20b-7f27-4468-aab2-65d0c744c918",
+        "49721876-1acf-4417-8cf9-161e53d631cf"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "pichichi-trophy",
+      "display_name": "Pichichi Trophy",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "2b0aa20b-7f27-4468-aab2-65d0c744c918",
+        "74d0d6bd-43ce-4a3a-877e-83737a1a2567"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "delio-onnis",
+      "display_name": "Delio Onnis",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "ae0b9575-c8f1-4575-9f14-c7ba2556c573",
+        "6167a5f1-2ec4-4e3b-84d6-de588030521a"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "carabao-cup",
+      "display_name": "Carabao Cup",
+      "aliases": [
+        "League Cup"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a52a1de5-f1fd-43f2-ac31-e2432dfe1dc7",
+        "4348c26a-9b3e-45d9-8288-19ec5407d986"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "aritz-aduriz",
+      "display_name": "Aritz Aduriz",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "69ae2273-f161-499f-b971-6af16a7b65cd",
+        "40e43f32-5406-493a-8bef-c47039d23fbd"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "yaya-toure",
+      "display_name": "Yaya Touré",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "cd3ace8d-bbad-452e-944d-5eb2f123fa62",
+        "bd14053d-c80f-4d6f-b7a7-72f65a7eb080"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mark-schwarzer",
+      "display_name": "Mark Schwarzer",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "4348c26a-9b3e-45d9-8288-19ec5407d986",
+        "463959d0-f62e-4a80-a8e3-3d5ff5ed5e62"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "henrikh-mkhitaryan",
+      "display_name": "Henrikh Mkhitaryan",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "16510146-5705-40e1-9b2e-a240ca1b6552",
+        "4883be5b-7dfe-4026-bdc8-991439c2829f"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "julian-nagelsmann",
+      "display_name": "Julian Nagelsmann",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "1baf8a03-75bf-4003-9d21-f69a01d9d078",
+        "7cff2ccc-9b02-49c3-829d-21ff9b1ecc63"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dele-alli",
+      "display_name": "Dele Alli",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "d60a9b2b-9f7e-497d-b9c1-c2d98530a178",
+        "90fe24dc-2c31-45b8-8b64-4600c22219b6"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-ciudad-de-la-plata",
+      "display_name": "Estadio Ciudad de La Plata",
+      "aliases": [
+        "Estadio Único Diego Armando Maradona"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "370cf336-024f-4c82-a339-65c34917e5af",
+        "a7371555-f6ee-4138-aa48-8576d63d404c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kevin-keegan",
+      "display_name": "Kevin Keegan",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a27b4ba4-7e14-43e8-a89c-57df94958d9a",
+        "d2a7c41b-a41a-4d29-84f0-ec51e386ecbf"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alan-smith",
+      "display_name": "Alan Smith",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "9554089d-a642-4ce6-a1f4-cbc5dc3579a4",
+        "26542985-30d1-43bb-a73a-1b575399adf0"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "hajduk-split",
+      "display_name": "Hajduk Split",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "79e846be-7a22-4f08-b2e0-6155c2c05136",
+        "70634bc5-54ea-4047-9b80-24d990bd233f"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ua",
+      "display_name": "Ukraine",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "79e846be-7a22-4f08-b2e0-6155c2c05136",
+        "33e333aa-9a2f-490a-a14a-4c310455d5f5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "darijo-srna",
+      "display_name": "Darijo Srna",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "79e846be-7a22-4f08-b2e0-6155c2c05136",
+        "6ef3ad3b-77e1-45a0-bb60-0f474495aa45"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "atalanta",
+      "display_name": "Atalanta",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "0bf5d921-1cc4-4fd8-baae-da54d188e88d",
+        "d7d6bd8b-8328-4d2d-a563-b25f7254acee"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "norwich-city",
+      "display_name": "Norwich City",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "7cebf1c5-5d6e-47d8-a8e9-b9d00b454023",
+        "3df17aff-ed8b-43a1-89ff-e946c4e5890b"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "paulo-fonseca",
+      "display_name": "Paulo Fonseca",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "fcd3a0e8-583c-4c14-b8f3-b2e61c21bb4f",
+        "3e9a0d2a-60e6-4382-ba77-d595e6574b50"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "nemanja-matic",
+      "display_name": "Nemanja Matic",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "fcd3a0e8-583c-4c14-b8f3-b2e61c21bb4f",
+        "964a3bb7-362b-4b93-9fb7-616460dfbf76"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mario-jardel",
+      "display_name": "Mário Jardel",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "90d50a02-ee7f-44d1-b8a9-d15782663c26",
+        "a510c5fa-77c0-4226-88a9-55a626872d0f"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "primeira-liga",
+      "display_name": "Primeira Liga",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "90d50a02-ee7f-44d1-b8a9-d15782663c26",
+        "0f9193b1-5bdf-4e19-be2d-95e36bc96f29"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "major-league-soccer",
+      "display_name": "Major League Soccer",
+      "aliases": [
+        "MLS",
+        "Major League Soccer"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "df6cc097-1426-4f66-a2ae-bfa4411ae46a",
+        "9e476a7e-7a2e-429b-820b-49cab7c434de"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "torjagerkanone",
+      "display_name": "Torjägerkanone",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "228f37de-aafb-4e26-a9cc-208a4c75afbe",
+        "f5928327-a4e8-4f8d-a55c-d7ee01485e07"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jimmy-floyd-hasselbaink",
+      "display_name": "Jimmy Floyd Hasselbaink",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "7ba72568-7273-4177-8481-b1925535d470",
+        "99749f8b-1e03-408f-9e26-f93d2323b6d4"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "eredivisie",
+      "display_name": "Eredivisie",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "17ff02a0-c21f-453a-b641-8c5df0737994",
+        "9f496f34-24e9-42ba-98b5-fb2ff26b14ac"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "ernst-happel-stadion",
+      "display_name": "Ernst-Happel-Stadion",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "3cb7579f-944f-4239-a897-966b030dfd10",
+        "f72d2475-f1e2-4424-a8b8-8ad9f29c4aae"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "luis-enrique",
+      "display_name": "Luis Enrique",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "73a6b746-c1f6-4903-b722-16bceec3919c",
+        "58a3faba-8b46-407b-bf8b-1ba9e2d8ff2e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "pablo-zabaleta",
+      "display_name": "Pablo Zabaleta",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "1f8d9f36-f424-474e-938b-fedcb2822d5c",
+        "9135a2d7-c2c4-4621-b700-4d60eeb50037"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "pl",
+      "display_name": "Poland",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "7eb53d78-b6eb-46d6-9df2-d3f56b65929d",
+        "547a852b-af95-4821-b6e9-3c245a9155a6"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "victor-osimhen",
+      "display_name": "Victor Osimhen",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "17d83397-8c00-4c0e-ba19-3a811e2f3776",
+        "d10ae472-1558-41df-ada0-0e9218edf30e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "joshua-kimmich",
+      "display_name": "Joshua Kimmich",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "870cd13c-28db-4bde-bcc2-980764f1570d",
+        "0245064c-e0f7-40d8-9a92-fc52cb1b0dcd"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fluminense",
+      "display_name": "Fluminense",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "125badf2-fd52-4221-b6d5-47351132e69f",
+        "670b9b39-77b8-4839-8b42-2f1a7a7731d2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ian-rush",
+      "display_name": "Ian Rush",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "87200de5-1efb-4b90-ab3c-793073542d97",
+        "71930f48-5ed3-4812-b3f2-a559c878538d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jay-jay-okocha",
+      "display_name": "Jay-Jay Okocha",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "f84745bd-de92-42bd-89e0-8b990ae6bdf4",
+        "a200749b-8030-4ef4-91f0-31ffbf4b256c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "cska-moscow",
+      "display_name": "CSKA Moscow",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "4193ae6f-2295-4327-bbcc-a3d4887505ec",
+        "4b10c27a-1bb0-484b-9c51-02609273af0f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "paraguay",
+      "display_name": "Paraguay",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "af11df21-bb8f-4593-8b0c-90bf4595b4bf",
+        "3614a768-e2e1-490d-acb4-910d8b829655"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "chile",
+      "display_name": "Chile",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "af11df21-bb8f-4593-8b0c-90bf4595b4bf",
+        "1ecbafd7-7a6f-4306-af5b-0f6fbb2d02d6"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "cardiff-city",
+      "display_name": "Cardiff City",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "d7e97156-c840-459a-933a-7737ebda28aa",
+        "3df17aff-ed8b-43a1-89ff-e946c4e5890b"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "maracana",
+      "display_name": "Maracanã",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "670b9b39-77b8-4839-8b42-2f1a7a7731d2",
+        "fce8657c-5cd2-4adb-9d31-9ff27e9891ff"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "arena-nationala",
+      "display_name": "Arena Națională",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "73f80ff8-0fb3-4692-987e-2dc50f911630",
+        "e0615a3d-4996-4592-b80a-f3f76db3a88a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "internazionale",
+      "display_name": "Internazionale",
+      "aliases": [
+        "Internacional"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "31bbea25-dbc6-45a0-80f7-6c47868fb682",
+        "2f78c9ca-0ce3-48a7-9436-145f06d43741"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "china",
+      "display_name": "China",
+      "aliases": [
+        "Chivas"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "f42de32d-8cbe-4202-8cb4-b4353114df90",
+        "4bc631bb-f78e-4c4b-9168-9e862db636ca"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "cameroon-national-football-team",
+      "display_name": "Cameroon national football team",
+      "aliases": [
+        "Cameroon"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "2c50ebd0-ef75-4436-be68-ca00bede68db",
+        "b15f0602-af76-4866-8021-d655884d72c2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ole-gunnar-solskjær",
+      "display_name": "Ole Gunnar Solskjær",
+      "aliases": [],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "8d731cdd-0c14-4e5b-aaaa-d935dd437479",
+        "c6067602-b9b1-4b44-9e70-1c68f02a725b"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "real-mallorca",
+      "display_name": "Real Mallorca",
+      "aliases": [
+        "Mallorca"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "548509fb-2a94-44f2-a26a-bd40cc8179ba",
+        "ef0a0fd4-0e28-4ca2-a809-42c5e712009e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-kaiserslautern",
+      "display_name": "FC Kaiserslautern",
+      "aliases": [
+        "1. FC Kaiserslautern"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "4f86c3c5-029e-4eed-95bc-4a63eeb81014",
+        "dcea392f-1ddf-490c-8dc3-60f49216f551"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "super-lig",
+      "display_name": "Süper Lig",
+      "aliases": [
+        "Turkish Süper Lig"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "86a53d23-13fc-439e-b380-1545c2c43729",
+        "96dc7442-28d3-46a4-bdae-9e01941de36f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sweden-national-football-team",
+      "display_name": "Sweden national football team",
+      "aliases": [
+        "Sweden"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "d60a9b2b-9f7e-497d-b9c1-c2d98530a178",
+        "f45978dd-265a-4db5-9584-017012ff84fd"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "estudiantes-de-la-plata",
+      "display_name": "Estudiantes de La Plata",
+      "aliases": [
+        "Estudiantes"
+      ],
+      "mention_count": 2,
+      "sample_question_ids": [
+        "a7371555-f6ee-4138-aa48-8576d63d404c",
+        "d4555376-e321-4e51-a357-6a5f0ad78e3d"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "vicente-calderon",
+      "display_name": "Vicente Calderón",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b7e52a06-ad42-4e23-8cb1-6b82e9454069"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "lamia",
+      "display_name": "Lamia FC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9e4764c1-1b37-4a9a-945b-455079b79aee"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "lamia-municipal-stadium",
+      "display_name": "Lamia Municipal Stadium",
+      "aliases": [
+        "Athanasios Diakos Stadium"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9e4764c1-1b37-4a9a-945b-455079b79aee"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sk-slavia-prague",
+      "display_name": "SK Slavia Prague",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4b6899d6-959a-480a-a94d-87ddc26d1ba3"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadion-eden",
+      "display_name": "Stadion Eden",
+      "aliases": [
+        "Eden Arena"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4b6899d6-959a-480a-a94d-87ddc26d1ba3"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stade-velodrome",
+      "display_name": "Stade Vélodrome",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "84f6e2b4-42c3-492b-a599-8907b539a789"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jari-litmanen",
+      "display_name": "Jari Litmanen",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9783dd22-6b15-4f30-bad8-b94af4d5101b"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "mtk-budapest",
+      "display_name": "MTK Budapest",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "63d9b5b9-fe11-49c4-bfcf-512985693cbf"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "vitor-baia",
+      "display_name": "Vítor Baía",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cfa96cb2-0fd2-42ee-9d71-e482fe9a37f8"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "paddy-kenny",
+      "display_name": "Paddy Kenny",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4c9120ee-de05-495a-bc19-fa3f84433345"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "qpr",
+      "display_name": "QPR",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4c9120ee-de05-495a-bc19-fa3f84433345"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "piers-morgan",
+      "display_name": "Piers Morgan",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "83e5dbad-b036-4fac-bfc3-57642f330171"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "molde-fk",
+      "display_name": "Molde FK",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5ed0755f-0945-43c7-822a-7547769534b5"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-sheriff-tiraspol",
+      "display_name": "FC Sheriff Tiraspol",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d41ca02f-aab8-4fde-b48c-243f3b71b249"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "sheriff-stadium",
+      "display_name": "Sheriff Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d41ca02f-aab8-4fde-b48c-243f3b71b249"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadio-comunale",
+      "display_name": "Stadio Comunale",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a58d5ccd-47a4-436b-928e-74195543af30"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "stefan-de-vrij",
+      "display_name": "Stefan de Vrij",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e9f00fc1-748e-459e-91f8-49014245965c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "peter-osgood",
+      "display_name": "Peter Osgood",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "200e98f8-5ae5-4391-a06c-20b212e5800f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "john-dempsey",
+      "display_name": "John Dempsey",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "200e98f8-5ae5-4391-a06c-20b212e5800f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "davor-suker",
+      "display_name": "Davor Šuker",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "397dc9a4-b161-47f7-b0ac-9ce5daf1f432"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "trevor-brooking",
+      "display_name": "Trevor Brooking",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2457034b-e727-4eaa-bfdd-4e09c8143eca"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "sir-alex-ferguson",
+      "display_name": "Sir Alex Ferguson",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0dfb6ff3-d1de-4033-916e-1a362652cb83"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "tottenham",
+      "display_name": "Tottenham",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f47c28d2-d7e8-48f0-a98c-64be231c0e90"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "hjk-helsinki",
+      "display_name": "HJK Helsinki",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ae5b053e-42fa-47ae-a48d-af19079d8792"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "veikkausliiga",
+      "display_name": "Veikkausliiga",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ae5b053e-42fa-47ae-a48d-af19079d8792"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "fi",
+      "display_name": "Finland",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ae5b053e-42fa-47ae-a48d-af19079d8792"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "stefan-kovacs",
+      "display_name": "Stefan Kovacs",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1dc608f1-70d8-41b8-947c-9545c5a425d3"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "norway-national-football-team",
+      "display_name": "Norway national football team",
+      "aliases": [
+        "Norway"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "89232e57-a594-4a24-9221-6b830bbe2cf9"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "iceland-national-football-team",
+      "display_name": "Iceland national football team",
+      "aliases": [
+        "Iceland"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "89232e57-a594-4a24-9221-6b830bbe2cf9"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "heimir-hallgrimsson",
+      "display_name": "Heimir Hallgrímsson",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "89232e57-a594-4a24-9221-6b830bbe2cf9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "laurent-pokou",
+      "display_name": "Laurent Pokou",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "rashidi-yekini",
+      "display_name": "Rashidi Yekini",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "hassan-el-shazly",
+      "display_name": "Hassan El Shazly",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "patrick-mboma",
+      "display_name": "Patrick Mboma",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "hossam-hassan",
+      "display_name": "Hossam Hassan",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "sadio-mane",
+      "display_name": "Sadio Mané",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "db756f0c-8553-48a9-8c41-da8b7d2f9a56"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "eder",
+      "display_name": "Eder",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e160fbdd-6192-4d44-bab7-3c43b32b4700"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jurgen-klinsmann",
+      "display_name": "Jürgen Klinsmann",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a191f34b-2a64-4129-a657-e862f233c727"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gregor-kobel",
+      "display_name": "Gregor Kobel",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6d41cc78-7e43-4503-a825-ad87b4d9a554"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "emre-can",
+      "display_name": "Emre Can",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6d41cc78-7e43-4503-a825-ad87b4d9a554"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "donyell-malen",
+      "display_name": "Donyell Malen",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6d41cc78-7e43-4503-a825-ad87b4d9a554"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "miguel-munoz",
+      "display_name": "Miguel Muñoz",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "11f28ed9-05ec-4ff7-8f8b-6ce4aa53e1ff"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "helenio-herrera",
+      "display_name": "Helenio Herrera",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "11f28ed9-05ec-4ff7-8f8b-6ce4aa53e1ff"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "ferdinand-daucik",
+      "display_name": "Ferdinand Daučík",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "11f28ed9-05ec-4ff7-8f8b-6ce4aa53e1ff"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "clarence-seedorf",
+      "display_name": "Clarence Seedorf",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c2d95ab7-57fb-4829-bf36-8ee5fdbe6d41"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "valletta-fc",
+      "display_name": "Valletta FC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "229ef20f-d0e8-4bc6-89e4-bf5f501caba8"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "mt",
+      "display_name": "Malta",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "229ef20f-d0e8-4bc6-89e4-bf5f501caba8"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "paul-breitner",
+      "display_name": "Paul Breitner",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "40a6e673-904f-4e5f-9da4-4be9e8a65ca0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kurt-zouma",
+      "display_name": "Kurt Zouma",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "05c454cc-341d-4e4d-8c3e-5e0bc269266f"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "papara-park",
+      "display_name": "Papara Park",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "097a3848-8bc6-44c8-969c-a7dd931d1628"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "frederic-kanoute",
+      "display_name": "Frédéric Kanouté",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6647cef4-3eeb-4298-8ac3-5b5bdd639932"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sheffield-wednesday",
+      "display_name": "Sheffield Wednesday",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9204909c-8c62-4696-8aa0-9f7a9f811dc1"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "george-weah",
+      "display_name": "George Weah",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "38ba72bc-06bc-4113-a4dc-a993f4f9d751"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "mircea-lucescu",
+      "display_name": "Mircea Lucescu",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "948a38d2-3117-40e6-94fe-c7a2ee083060"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ruud-van-nistelrooy",
+      "display_name": "Ruud van Nistelrooy",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0fb106a7-dd1d-485a-a19f-94bfc57aed1c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "karlsruher-sc",
+      "display_name": "Karlsruher SC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "74bd9094-4d42-4a46-9e68-907fa4d6dd12"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "tannadice-park",
+      "display_name": "Tannadice Park",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "79df6641-152c-4c59-9bd4-ac468871d831"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "andy-cole",
+      "display_name": "Andy Cole",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "94855a13-1a9c-4c37-a81b-300cae4a1b3d"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "cm",
+      "display_name": "Cameroon",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3b4f4a84-7feb-4149-ad2d-47e9e88c7a74"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "robinho",
+      "display_name": "Robinho",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "84b9bade-a4ed-4788-bb81-08199fb66284"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "wesley-sneijder",
+      "display_name": "Wesley Sneijder",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "84b9bade-a4ed-4788-bb81-08199fb66284"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "felipe-melo",
+      "display_name": "Felipe Melo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "84b9bade-a4ed-4788-bb81-08199fb66284"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "enzo-scifo",
+      "display_name": "Enzo Scifo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "06cf25e0-df55-4041-b5e2-6103ed6a4026"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jan-ceulemans",
+      "display_name": "Jan Ceulemans",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "06cf25e0-df55-4041-b5e2-6103ed6a4026"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "igor-belanov",
+      "display_name": "Igor Belanov",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8906406f-6475-4853-80f5-979d434f09da"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "costa-rica",
+      "display_name": "Costa Rica",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f42de32d-8cbe-4202-8cb4-b4353114df90"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "nigeria",
+      "display_name": "Nigeria",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f42de32d-8cbe-4202-8cb4-b4353114df90"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "christine-sinclair",
+      "display_name": "Christine Sinclair",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3e1862de-4b23-4e71-99e8-1b11db1cb613"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "canada",
+      "display_name": "Canada",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3e1862de-4b23-4e71-99e8-1b11db1cb613"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "abby-wambach",
+      "display_name": "Abby Wambach",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3e1862de-4b23-4e71-99e8-1b11db1cb613"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "josef-masopust",
+      "display_name": "Josef Masopust",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "902c1d59-fa6d-4ef7-9ddf-3dff32f6745b"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "dukla-prague",
+      "display_name": "Dukla Prague",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "902c1d59-fa6d-4ef7-9ddf-3dff32f6745b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "valeri-bojinov",
+      "display_name": "Valeri Bojinov",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8b23f84d-47ef-4976-9730-5432fab191e2"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "lecce",
+      "display_name": "Lecce",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8b23f84d-47ef-4976-9730-5432fab191e2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "sunil-chhetri",
+      "display_name": "Sunil Chhetri",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d6ff9bca-3fe6-4fbd-998b-29aba7cbfef0"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "india",
+      "display_name": "India",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d6ff9bca-3fe6-4fbd-998b-29aba7cbfef0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alexis-sanchez",
+      "display_name": "Alexis Sánchez",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bf4e012f-941a-477e-a6c0-f588304c72ba"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kostas-mitroglou",
+      "display_name": "Kostas Mitroglou",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bf4e012f-941a-477e-a6c0-f588304c72ba"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "greek-cup",
+      "display_name": "Greek Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bf4e012f-941a-477e-a6c0-f588304c72ba"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jens-lehmann",
+      "display_name": "Jens Lehmann",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bb6a4db3-5e84-468c-8462-c67b06c88988"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "sol-campbell",
+      "display_name": "Sol Campbell",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bb6a4db3-5e84-468c-8462-c67b06c88988"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "juliano-belletti",
+      "display_name": "Juliano Belletti",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bb6a4db3-5e84-468c-8462-c67b06c88988"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "vasco-da-gama",
+      "display_name": "Vasco da Gama",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "36bc6b0e-79a6-495e-ab45-85c845746d02"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "charly-korbel",
+      "display_name": "Charly Körbel",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "81f4c039-d088-47f7-a180-d0463ae94e22"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "manfred-kaltz",
+      "display_name": "Manfred Kaltz",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "81f4c039-d088-47f7-a180-d0463ae94e22"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "klaus-fichtel",
+      "display_name": "Klaus Fichtel",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "81f4c039-d088-47f7-a180-d0463ae94e22"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "miroslav-votava",
+      "display_name": "Miroslav Votava",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "81f4c039-d088-47f7-a180-d0463ae94e22"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "thomas-berthold",
+      "display_name": "Thomas Berthold",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "81f4c039-d088-47f7-a180-d0463ae94e22"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "super-league-1",
+      "display_name": "Super League 1",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f54b9e3-755f-4ade-a79e-8fe98c0a1818"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "thomas-mavros",
+      "display_name": "Thomas Mavros",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f54b9e3-755f-4ade-a79e-8fe98c0a1818"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "krzysztof-warzycha",
+      "display_name": "Krzysztof Warzycha",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f54b9e3-755f-4ade-a79e-8fe98c0a1818"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mimis-papaioannou",
+      "display_name": "Mimis Papaioannou",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f54b9e3-755f-4ade-a79e-8fe98c0a1818"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "antonis-antoniadis",
+      "display_name": "Antonis Antoniadis",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f54b9e3-755f-4ade-a79e-8fe98c0a1818"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "georgios-sideris",
+      "display_name": "Georgios Sideris",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f54b9e3-755f-4ade-a79e-8fe98c0a1818"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "lee-dong-gook",
+      "display_name": "Lee Dong-gook",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "64afb3b2-c0c5-4786-b05a-bd7535fef6f5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "almoez-ali",
+      "display_name": "Almoez Ali",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "64afb3b2-c0c5-4786-b05a-bd7535fef6f5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "naohiro-takahara",
+      "display_name": "Naohiro Takahara",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "64afb3b2-c0c5-4786-b05a-bd7535fef6f5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ali-mabkhout",
+      "display_name": "Ali Mabkhout",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "64afb3b2-c0c5-4786-b05a-bd7535fef6f5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "younis-mahmoud",
+      "display_name": "Younis Mahmoud",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "64afb3b2-c0c5-4786-b05a-bd7535fef6f5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "rivaldo",
+      "display_name": "Rivaldo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "68ab4348-2102-4daf-a884-e47cdf022d3a"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "joachim-low",
+      "display_name": "Joachim Löw",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "327ed3ed-2f99-4aa3-9ddc-eff0a5cdff36"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jonas-gutierrez",
+      "display_name": "Jonás Gutiérrez",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "362337c6-b9a3-46bc-8a31-31dc6a1bb25e"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "championship",
+      "display_name": "Championship",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "362337c6-b9a3-46bc-8a31-31dc6a1bb25e"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-euro-2016",
+      "display_name": "UEFA Euro 2016",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "81a3e57d-7f44-4a6d-8fe0-0cebaa2b8908"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-euro-2012",
+      "display_name": "UEFA Euro 2012",
+      "aliases": [
+        "Euro 2012"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "dadfc50a-55a8-45e4-89e8-63c86b9a3e08"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "branislav-ivanovic",
+      "display_name": "Branislav Ivanović",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "829aeab1-f8f6-4888-8736-77d2a9095971"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "japan",
+      "display_name": "Japan",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cda188ca-0f9d-4fe8-a961-b73815e9173e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gary-cahill",
+      "display_name": "Gary Cahill",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "346a625d-7c13-4685-a973-87e63fee0a06"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "david-luiz",
+      "display_name": "David Luiz",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "346a625d-7c13-4685-a973-87e63fee0a06"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "thiago-silva",
+      "display_name": "Thiago Silva",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "346a625d-7c13-4685-a973-87e63fee0a06"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jude-bellingham",
+      "display_name": "Jude Bellingham",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fca9eb98-771b-4a11-8c64-840acb50bb34"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sporting-kansas-city",
+      "display_name": "Sporting Kansas City",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4cb3538b-b7cc-45ce-ac4b-de58ad83070a"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "childrens-mercy-park",
+      "display_name": "Children's Mercy Park",
+      "aliases": [
+        "Livestrong Sporting Park",
+        "Sporting Park"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4cb3538b-b7cc-45ce-ac4b-de58ad83070a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "samuel-chukwueze",
+      "display_name": "Samuel Chukwueze",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b6e53047-4615-401d-a3da-4db14fe12dce"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "fabio-quagliarella",
+      "display_name": "Fabio Quagliarella",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "758a7e8f-7218-4ca9-9f9e-3c375b66c498"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "derby-county",
+      "display_name": "Derby County",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "90410a42-a8fd-496e-bbbd-9b04a8e5d256"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "olimpiyskiy-national-sports-complex",
+      "display_name": "Olimpiyskiy National Sports Complex",
+      "aliases": [
+        "Olimpiyskiy National Sports Complex"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "086b35db-db7c-45d7-ba08-40f6b1332e02"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mauro-icardi",
+      "display_name": "Mauro Icardi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e64162d5-b170-4671-9abf-3245db9e0bd0"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "sukru-saracoglu-stadium",
+      "display_name": "Şükrü Saracoğlu Stadium",
+      "aliases": [
+        "Chobani Stadium Fenerbahçe Şükrü Saracoğlu Sports Complex"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "64ee11d3-254b-42fd-b49e-df175574282e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "geremi-njitap",
+      "display_name": "Geremi Njitap",
+      "aliases": [
+        "Geremi"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "579a82f2-1329-413d-a781-3ec58e785444"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "lille-osc",
+      "display_name": "Lille OSC",
+      "aliases": [
+        "Lille"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c96cd7a2-9627-4e29-9715-18977edf80da"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "motherwell",
+      "display_name": "Motherwell",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c88aaab9-0ecd-4cb8-a055-917434735af7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ivan-provedel",
+      "display_name": "Ivan Provedel",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "90ce96ac-d4cc-413d-836a-cc0b9505b3e0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "morgan-de-sanctis",
+      "display_name": "Morgan De Sanctis",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "90ce96ac-d4cc-413d-836a-cc0b9505b3e0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "samir-handanovic",
+      "display_name": "Samir Handanović",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "90ce96ac-d4cc-413d-836a-cc0b9505b3e0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gianluigi-donnarumma",
+      "display_name": "Gianluigi Donnarumma",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "90ce96ac-d4cc-413d-836a-cc0b9505b3e0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "papiss-cisse",
+      "display_name": "Papiss Cissé",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "24d8aed3-3153-415a-9bde-be94dd34b7d8"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "hnk-rijeka",
+      "display_name": "HNK Rijeka",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1f691183-31f2-43ec-a3a5-24f90c9e3904"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "rujevica-stadium",
+      "display_name": "Rujevica Stadium",
+      "aliases": [
+        "Stadion Rujevica"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1f691183-31f2-43ec-a3a5-24f90c9e3904"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "dynamo-dresden",
+      "display_name": "Dynamo Dresden",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5894652a-13e9-4cbe-af0f-c538bb69ac00"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "fdgb-pokal",
+      "display_name": "FDGB-Pokal",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5894652a-13e9-4cbe-af0f-c538bb69ac00"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bfc-dynamo",
+      "display_name": "BFC Dynamo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5894652a-13e9-4cbe-af0f-c538bb69ac00"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marquinhos",
+      "display_name": "Marquinhos",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "14f971f2-78ec-40e4-a5b7-5d1dc4d2433a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "eric-maxim-choupo-moting",
+      "display_name": "Eric Maxim Choupo-Moting",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "14f971f2-78ec-40e4-a5b7-5d1dc4d2433a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "botafogo",
+      "display_name": "Botafogo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7aa22b79-e956-4ad7-b366-fc97a4ea21aa"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "taca-brasil",
+      "display_name": "Taça Brasil",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7aa22b79-e956-4ad7-b366-fc97a4ea21aa"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fortaleza",
+      "display_name": "Fortaleza",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7aa22b79-e956-4ad7-b366-fc97a4ea21aa"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "diego-costa",
+      "display_name": "Diego Costa",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5b8361a2-7bd0-40dc-9a34-f94c8e1b51e7"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "cfr-cluj",
+      "display_name": "CFR Cluj",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0efb4254-1a49-458a-ad6d-6c04083b3198"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fk-velez-mostar",
+      "display_name": "FK Velež Mostar",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "34de6bcb-4744-4931-8a23-f0e33fbbcaf4"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadion-rodeni",
+      "display_name": "Stadion Rođeni",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "34de6bcb-4744-4931-8a23-f0e33fbbcaf4"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ba",
+      "display_name": "Bosnia and Herzegovina",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "34de6bcb-4744-4931-8a23-f0e33fbbcaf4"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "wembley",
+      "display_name": "Wembley",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7f5fda83-12ed-4cf8-ba3e-5c0bfd4c35b1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "los-angeles-aztecs",
+      "display_name": "Los Angeles Aztecs",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a163b4e4-0fa5-439d-9cb6-a33fd0b21912"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "nk-maribor",
+      "display_name": "NK Maribor",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1f2baf7f-bab8-4706-97ab-6a296a68d158"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "ljudski-vrt",
+      "display_name": "Ljudski vrt",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1f2baf7f-bab8-4706-97ab-6a296a68d158"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "si",
+      "display_name": "Slovenia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1f2baf7f-bab8-4706-97ab-6a296a68d158"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "gd-estoril-praia",
+      "display_name": "G.D. Estoril Praia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4acc2943-7530-4472-80e5-b17ef1faf72f"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-antonio-coimbra-da-mota",
+      "display_name": "Estádio António Coimbra da Mota",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4acc2943-7530-4472-80e5-b17ef1faf72f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ian-callaghan",
+      "display_name": "Ian Callaghan",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "50bb9823-a00e-47cc-847f-6469da022f65"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "emlyn-hughes",
+      "display_name": "Emlyn Hughes",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "50bb9823-a00e-47cc-847f-6469da022f65"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ray-clemence",
+      "display_name": "Ray Clemence",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "50bb9823-a00e-47cc-847f-6469da022f65"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "allianz-stadium",
+      "display_name": "Allianz Stadium",
+      "aliases": [
+        "Juventus Stadium"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c1a08de5-5ccf-4bc3-92fc-2fc3e0f6e376"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "eddie-howe",
+      "display_name": "Eddie Howe",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4bab35de-f46f-4d88-b58d-77eb2482b20a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "trevoh-chalobah",
+      "display_name": "Trevoh Chalobah",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4bab35de-f46f-4d88-b58d-77eb2482b20a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "anthony-gordon",
+      "display_name": "Anthony Gordon",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4bab35de-f46f-4d88-b58d-77eb2482b20a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bursaspor",
+      "display_name": "Bursaspor",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "96dc7442-28d3-46a4-bdae-9e01941de36f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "istanbul-basaksehir",
+      "display_name": "İstanbul Başakşehir",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "96dc7442-28d3-46a4-bdae-9e01941de36f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "aris-thessaloniki",
+      "display_name": "Aris Thessaloniki",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b4d1809c-749f-491c-bf85-f4467535e14c"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "kleanthis-vikelidis-stadium",
+      "display_name": "Kleanthis Vikelidis Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b4d1809c-749f-491c-bf85-f4467535e14c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "aek-larnaca",
+      "display_name": "AEK Larnaca",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a88746d1-3b34-4a4d-ba4d-0223621c2174"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "aek-arena-georgios-karapatakis",
+      "display_name": "AEK Arena – Georgios Karapatakis",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a88746d1-3b34-4a4d-ba4d-0223621c2174"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "kaa-gent",
+      "display_name": "K.A.A. Gent",
+      "aliases": [
+        "Gent"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "01c3d610-4b3f-410d-8065-d187deecd108"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-midtjylland",
+      "display_name": "FC Midtjylland",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9bdf7063-204a-421c-ac2d-f4e781b44548"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "mch-arena",
+      "display_name": "MCH Arena",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9bdf7063-204a-421c-ac2d-f4e781b44548"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "new-york-red-bulls",
+      "display_name": "New York Red Bulls",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "18c597ca-69b9-44c8-91cd-120901020167"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "jurgen-klopp",
+      "display_name": "Jürgen Klopp",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d3cf16c4-afef-497e-a25a-14b6f50b8c91"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-carl-zeiss-jena",
+      "display_name": "FC Carl Zeiss Jena",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2a330eae-bef7-407e-8942-278207dbffb0"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "ernst-abbe-sportfeld",
+      "display_name": "Ernst-Abbe-Sportfeld",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2a330eae-bef7-407e-8942-278207dbffb0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "luis-alberto",
+      "display_name": "Luis Alberto",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4573a286-8675-463b-ac83-893ee1f6f3f6"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "maurizio-sarri",
+      "display_name": "Maurizio Sarri",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4573a286-8675-463b-ac83-893ee1f6f3f6"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sc-cambuur",
+      "display_name": "SC Cambuur",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "24ccf049-278b-4332-b5b5-99285969b5ba"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "kooi-stadion",
+      "display_name": "Kooi Stadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "24ccf049-278b-4332-b5b5-99285969b5ba"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "cambuur-stadion",
+      "display_name": "Cambuur Stadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "24ccf049-278b-4332-b5b5-99285969b5ba"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "lautaro-martinez",
+      "display_name": "Lautaro Martínez",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "08f27558-2c73-4302-b78b-e54a8f5090e2"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "mino-raiola",
+      "display_name": "Mino Raiola",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8323acaa-6e0c-4b3e-8d4c-e7eac613bfe8"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "rafaela-pimenta",
+      "display_name": "Rafaela Pimenta",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8323acaa-6e0c-4b3e-8d4c-e7eac613bfe8"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "olivier-giroud",
+      "display_name": "Olivier Giroud",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c8317df9-8447-44a6-ac7a-461009429bb7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "raul-gonzalez",
+      "display_name": "Raúl González",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "90a7bb9e-0664-4eca-9ff2-0e53a82c064d"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-do-bessa-seculo-xxi",
+      "display_name": "Estádio do Bessa Século XXI",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "72791ad2-552e-4351-a4d0-04bbe51b2482"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "claudio-ranieri",
+      "display_name": "Claudio Ranieri",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "88741ca0-ae4d-44d9-a40b-42d2c31d40c7"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bsc-young-boys",
+      "display_name": "BSC Young Boys",
+      "aliases": [
+        "Young Boys"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "65666bbb-884c-49a4-8835-983725de072b"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "wankdorf-stadium",
+      "display_name": "Wankdorf Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "65666bbb-884c-49a4-8835-983725de072b"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "valeriy-nepomnyashchy",
+      "display_name": "Valeriy Nepomnyashchy",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a4403d41-dbca-4f8f-b8e8-6dbbb4050ea7"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "tom-tomsk",
+      "display_name": "Tom Tomsk",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a4403d41-dbca-4f8f-b8e8-6dbbb4050ea7"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "baltika-kaliningrad",
+      "display_name": "Baltika Kaliningrad",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a4403d41-dbca-4f8f-b8e8-6dbbb4050ea7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "daley-blind",
+      "display_name": "Daley Blind",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d123df5c-3a6f-406c-b81e-0366f9dca2cc"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "joel-veltman",
+      "display_name": "Joël Veltman",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d123df5c-3a6f-406c-b81e-0366f9dca2cc"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jorginho",
+      "display_name": "Jorginho",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d123df5c-3a6f-406c-b81e-0366f9dca2cc"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "reece-james",
+      "display_name": "Reece James",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d123df5c-3a6f-406c-b81e-0366f9dca2cc"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadionul-ilie-oana",
+      "display_name": "Stadionul Ilie Oană",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1717cf2b-a196-4ed2-88a8-d2ea447c6c1b"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "petrolul-ploiesti",
+      "display_name": "Petrolul Ploiești",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1717cf2b-a196-4ed2-88a8-d2ea447c6c1b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alexis-mac-allister",
+      "display_name": "Alexis Mac Allister",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7c37bb22-c0a9-45d0-831d-afa25f8d2177"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "morten-gamst-pedersen",
+      "display_name": "Morten Gamst Pedersen",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "201c69d9-0a02-4520-9629-16d24aa449ce"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "perugia",
+      "display_name": "Perugia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "89675e1a-fa3d-4e1a-a2e3-aa394897387a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "karl-heinz-riedle",
+      "display_name": "Karl-Heinz Riedle",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1d41f286-d413-4e3e-b1ff-89fbe2b765de"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadion-u-nisy",
+      "display_name": "Stadion U Nisy",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4615cc8d-518b-4550-b837-55f046469f6d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "slovan-liberec",
+      "display_name": "Slovan Liberec",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4615cc8d-518b-4550-b837-55f046469f6d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "tampa-bay-mutiny",
+      "display_name": "Tampa Bay Mutiny",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8b29f3f8-5ce6-4aea-80ca-8874bb89fc43"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "miami-fusion",
+      "display_name": "Miami Fusion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8b29f3f8-5ce6-4aea-80ca-8874bb89fc43"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "colorado-rapids",
+      "display_name": "Colorado Rapids",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8b29f3f8-5ce6-4aea-80ca-8874bb89fc43"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "panama-national-football-team",
+      "display_name": "Panama national football team",
+      "aliases": [
+        "Panama"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2ca2126e-d2bd-476f-b2ce-b832f96346e4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "vangelis-mantzios",
+      "display_name": "Vangelis Mantzios",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e0914b41-a95e-4958-9c86-b8339195414b"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "egypt-national-football-team",
+      "display_name": "Egypt national football team",
+      "aliases": [
+        "Egypt"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2c50ebd0-ef75-4436-be68-ca00bede68db"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "rosenborg-bk",
+      "display_name": "Rosenborg BK",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5ae0d7fd-6cc0-470c-bd06-9b511682e48f"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "lerkendal-stadion",
+      "display_name": "Lerkendal Stadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5ae0d7fd-6cc0-470c-bd06-9b511682e48f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "xavi-hernandez",
+      "display_name": "Xavi Hernández",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fd7f2497-ceca-4595-b277-5c7a9c870be7"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-europa-conference-league",
+      "display_name": "UEFA Europa Conference League",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5079b594-28b0-466d-a3e1-53a4c2245cc1"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "nicolo-zaniolo",
+      "display_name": "Nicolò Zaniolo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5079b594-28b0-466d-a3e1-53a4c2245cc1"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "volksparkstadion",
+      "display_name": "Volksparkstadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8be84f0a-07ea-4fa4-a81d-884c28efca85"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "tehelne-pole",
+      "display_name": "Tehelne pole",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "96923a02-9d90-44d2-9ca6-ba9e82c9cba0"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "slovan-bratislava",
+      "display_name": "Slovan Bratislava",
+      "aliases": [
+        "ŠK Slovan Bratislava"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "96923a02-9d90-44d2-9ca6-ba9e82c9cba0"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "sk",
+      "display_name": "Slovakia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "96923a02-9d90-44d2-9ca6-ba9e82c9cba0"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "cn",
+      "display_name": "China",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "054d075b-c648-4b91-8e1a-c31766e56055"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "united-states-womens-national-team",
+      "display_name": "United States",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "054d075b-c648-4b91-8e1a-c31766e56055"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stade-cheikha-ould-boidiya",
+      "display_name": "Stade Cheikha Ould Boïdiya",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "50ab768a-c088-4c9d-b3b3-0a90260ad89e"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "mr",
+      "display_name": "Mauritania",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "50ab768a-c088-4c9d-b3b3-0a90260ad89e"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "el-hadj-hassan-gouled-aptidon-stadium",
+      "display_name": "El Hadj Hassan Gouled Aptidon Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "aa484850-103d-4ff0-ac06-d7eb9a79d4b4"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "dj",
+      "display_name": "Djibouti",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "aa484850-103d-4ff0-ac06-d7eb9a79d4b4"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "as-port",
+      "display_name": "AS Port",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "aa484850-103d-4ff0-ac06-d7eb9a79d4b4"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "raja-casablanca",
+      "display_name": "Raja Casablanca",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "653e87c0-7506-4a9d-816b-ff55a1a0905b"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ma",
+      "display_name": "Morocco",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "653e87c0-7506-4a9d-816b-ff55a1a0905b"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stade-mohammed-v",
+      "display_name": "Stade Mohammed V",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "653e87c0-7506-4a9d-816b-ff55a1a0905b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "andreas-brehme",
+      "display_name": "Andreas Brehme",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "948f9610-171a-40c9-b79a-44ff8b770d84"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "nuno-espirito-santo",
+      "display_name": "Nuno Espirito Santo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "286bda23-a3bb-41e5-af0c-c1af49d359b5"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "air-force-club",
+      "display_name": "Air Force Club",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "286bda23-a3bb-41e5-af0c-c1af49d359b5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "roberto-firmino",
+      "display_name": "Roberto Firmino",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3ecb6bdd-df8b-46eb-aae2-57d4fd1e8cfc"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "stade-de-reims",
+      "display_name": "Stade de Reims",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "de1b03e8-bb7c-46d2-ab87-bd3069560ba9"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fortuna-sittard",
+      "display_name": "Fortuna Sittard",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "af771ac2-5da0-4f69-97ca-0eec1931ef63"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "de-baandert",
+      "display_name": "De Baandert",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "af771ac2-5da0-4f69-97ca-0eec1931ef63"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "fortuna-sittard-stadion",
+      "display_name": "Fortuna Sittard Stadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "af771ac2-5da0-4f69-97ca-0eec1931ef63"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-azteca",
+      "display_name": "Estadio Azteca",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bb00f629-5d8f-42ed-ab8c-3d657c66638b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kenny-dalglish",
+      "display_name": "Kenny Dalglish",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7c5a78dd-1ab2-4d46-9678-94f108248df8"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "english-first-division",
+      "display_name": "English First Division",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7c5a78dd-1ab2-4d46-9678-94f108248df8"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-basel",
+      "display_name": "FC Basel",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ceeb7aba-4290-41ca-a77c-34322e84198a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sv-werder-bremen",
+      "display_name": "SV Werder Bremen",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ceeb7aba-4290-41ca-a77c-34322e84198a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sturm-graz",
+      "display_name": "Sturm Graz",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ceeb7aba-4290-41ca-a77c-34322e84198a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "juan-sebastian-veron",
+      "display_name": "Juan Sebastián Verón",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d4555376-e321-4e51-a357-6a5f0ad78e3d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "osters-if",
+      "display_name": "Östers IF",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "99b21ca3-a36b-4327-9f18-9c7e563bcf33"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "allsvenskan",
+      "display_name": "Allsvenskan",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "99b21ca3-a36b-4327-9f18-9c7e563bcf33"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "varendsvallen",
+      "display_name": "Värendsvallen",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "99b21ca3-a36b-4327-9f18-9c7e563bcf33"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "widzew-lodz",
+      "display_name": "Widzew Łódź",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "23bd6af9-2687-4b4d-be13-c1f569758537"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dejan-savicevic",
+      "display_name": "Dejan Savićević",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e1506eba-d301-42b9-88f3-9086fe5e23d3"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mark-crossley",
+      "display_name": "Mark Crossley",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2f508f55-6331-4981-bb54-c3a728609129"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "braga",
+      "display_name": "Braga",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ec79700b-3034-4f93-9ad7-49eb4d927691"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jussi-jaaskelainen",
+      "display_name": "Jussi Jääskeläinen",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5eb22262-7659-477d-910a-6d8a222b7366"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gary-neville",
+      "display_name": "Gary Neville",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c5f93ddd-abec-4fa5-a798-d06b092c1a16"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ir",
+      "display_name": "Iran",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "34ab5bcf-313a-4117-9ec2-35962fa4d8e8"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadio-friuli",
+      "display_name": "Stadio Friuli",
+      "aliases": [
+        "Bluenery Stadium",
+        "Dacia Arena"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "caf0bbdc-878b-4ee9-8539-42187fc64797"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "udinese",
+      "display_name": "Udinese Calcio",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "caf0bbdc-878b-4ee9-8539-42187fc64797"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "portman-road",
+      "display_name": "Portman Road",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "aefd9400-0512-4470-b6bc-1d92eb998106"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "olympic-stadium-amsterdam",
+      "display_name": "Olympic Stadium, Amsterdam",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "aefd9400-0512-4470-b6bc-1d92eb998106"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kieran-trippier",
+      "display_name": "Kieran Trippier",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "81c59505-e2fe-49fd-99f8-fe2ca1e3659c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ivan-perisic",
+      "display_name": "Ivan Perišić",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "81c59505-e2fe-49fd-99f8-fe2ca1e3659c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mario-mandzukic",
+      "display_name": "Mario Mandžukić",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "81c59505-e2fe-49fd-99f8-fe2ca1e3659c"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "ataturk-olympic-stadium",
+      "display_name": "Atatürk Olympic Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "89718799-b621-4fd5-9ab3-68873df04b70"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "al-ettifaq",
+      "display_name": "Al-Ettifaq",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3cd7f8f0-f9aa-4c2e-8732-94f5ace1acde"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jordan-henderson",
+      "display_name": "Jordan Henderson",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3cd7f8f0-f9aa-4c2e-8732-94f5ace1acde"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "steven-gerrard",
+      "display_name": "Steven Gerrard",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3cd7f8f0-f9aa-4c2e-8732-94f5ace1acde"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "micah-richards",
+      "display_name": "Micah Richards",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ec6a060a-f194-4c09-9527-0ae8e2a1af39"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "richard-keys",
+      "display_name": "Richard Keys",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ec6a060a-f194-4c09-9527-0ae8e2a1af39"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kate-abdo",
+      "display_name": "Kate Abdo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ec6a060a-f194-4c09-9527-0ae8e2a1af39"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "serbian-superliga",
+      "display_name": "Serbian SuperLiga",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8bad682a-ae10-4990-b906-24568c025abd"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jason-puncheon",
+      "display_name": "Jason Puncheon",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "214cfeab-4cde-4388-ae4b-4bb46b851e5e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "juan-mata",
+      "display_name": "Juan Mata",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "214cfeab-4cde-4388-ae4b-4bb46b851e5e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jesse-lingard",
+      "display_name": "Jesse Lingard",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "214cfeab-4cde-4388-ae4b-4bb46b851e5e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sinop",
+      "display_name": "Sinop",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d0e8d602-edb0-4c69-8354-e91f134112e1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sao-paulo",
+      "display_name": "São Paulo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d0e8d602-edb0-4c69-8354-e91f134112e1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "1-fc-koln",
+      "display_name": "1. FC Köln",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9dcb84bf-7b47-4ba0-80bd-b080dcd583ea"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "unai-emery",
+      "display_name": "Unai Emery",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "63f2427e-2efe-408a-b1e5-1997711bba8f"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "juande-ramos",
+      "display_name": "Juande Ramos",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "63f2427e-2efe-408a-b1e5-1997711bba8f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "carles-puyol",
+      "display_name": "Carles Puyol",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "74b21f11-42c8-4863-b4d4-38005ca4268e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "luiz-adriano",
+      "display_name": "Luiz Adriano",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d4e99e9f-adbc-4b31-9fc7-4df1695d2a21"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ronaldinho",
+      "display_name": "Ronaldinho",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bbc5ab29-fc0c-48f3-9aa2-b2ceeb37cd54"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "dr-magalhaes-pessoa-stadium",
+      "display_name": "Dr. Magalhães Pessoa Stadium",
+      "aliases": [
+        "Estádio Dr. Magalhães Pessoa"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e1cc887e-f59d-47e8-ae1e-34f440e868fb"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "bobby-charlton",
+      "display_name": "Bobby Charlton",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b1ebe751-d971-4c6a-9124-7e34c64238e2"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "moses-mabhida-stadium",
+      "display_name": "Moses Mabhida Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "08e29e71-20a0-49f4-854a-7f53de30ae5f"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "za",
+      "display_name": "South Africa",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "08e29e71-20a0-49f4-854a-7f53de30ae5f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "rennes",
+      "display_name": "Rennes",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2126122c-6781-4891-b855-8a3a8a0a69fd"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "metz",
+      "display_name": "Metz",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2126122c-6781-4891-b855-8a3a8a0a69fd"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "norberto-mendez",
+      "display_name": "Norberto Méndez",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "dc90203a-f9da-4f87-afaf-a573b54128d7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "zizinho",
+      "display_name": "Zizinho",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "dc90203a-f9da-4f87-afaf-a573b54128d7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "paolo-guerrero",
+      "display_name": "Paolo Guerrero",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "dc90203a-f9da-4f87-afaf-a573b54128d7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mark-hughes",
+      "display_name": "Mark Hughes",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f7f638f3-4e67-448a-87f5-b0fbe6f458d5"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "feyenoord-stadion",
+      "display_name": "Feyenoord Stadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f7f638f3-4e67-448a-87f5-b0fbe6f458d5"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "is",
+      "display_name": "Iceland",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8ed6b8a0-064d-4b84-a96c-68be0054ecdf"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "nemanja-vidic",
+      "display_name": "Nemanja Vidić",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "25687d54-4342-4532-94f5-f3b6faacaee8"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "andrea-pirlo",
+      "display_name": "Andrea Pirlo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cc5053ca-fa75-44a5-bbe9-e0061cf83562"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "new-york-city-fc",
+      "display_name": "New York City FC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cc5053ca-fa75-44a5-bbe9-e0061cf83562"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "sammy-ofer-stadium",
+      "display_name": "Sammy Ofer Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3c694beb-c8d1-4888-85c5-3355f7f4f714"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "maccabi-haifa",
+      "display_name": "Maccabi Haifa",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3c694beb-c8d1-4888-85c5-3355f7f4f714"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "hapoel-haifa",
+      "display_name": "Hapoel Haifa",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3c694beb-c8d1-4888-85c5-3355f7f4f714"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "il",
+      "display_name": "Israel",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3c694beb-c8d1-4888-85c5-3355f7f4f714"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "dasaki-stadium",
+      "display_name": "Dasaki Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1c77b380-5c99-4615-920e-25a958aea102"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ethnikos-achna",
+      "display_name": "Ethnikos Achna",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1c77b380-5c99-4615-920e-25a958aea102"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "riazor",
+      "display_name": "Riazor",
+      "aliases": [
+        "Estadio Riazor"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1fdd4f9d-821b-41ed-8acf-ccefe698ae8d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "lev-yashin",
+      "display_name": "Lev Yashin",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4bfa40ad-b7ad-434d-a027-284b1a1321aa"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "javier-zanetti",
+      "display_name": "Javier Zanetti",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5a3647c6-e2dc-448d-986b-a952b41fbb9e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "talleres-de-remedios-de-escalada",
+      "display_name": "Talleres de Remedios de Escalada",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5a3647c6-e2dc-448d-986b-a952b41fbb9e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "banfield",
+      "display_name": "Banfield",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5a3647c6-e2dc-448d-986b-a952b41fbb9e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alessandro-altobelli",
+      "display_name": "Alessandro Altobelli",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "15f57616-cab1-49b6-b8dc-42d631279775"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "roberto-boninsegna",
+      "display_name": "Roberto Boninsegna",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "15f57616-cab1-49b6-b8dc-42d631279775"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "benito-lorenzi",
+      "display_name": "Benito Lorenzi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "15f57616-cab1-49b6-b8dc-42d631279775"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "luigi-cevenini-iii",
+      "display_name": "Luigi Cevenini III",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "15f57616-cab1-49b6-b8dc-42d631279775"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "laurent-robert",
+      "display_name": "Laurent Robert",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "865705a9-10c6-4b9c-96bd-4be43c923501"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gunnar-nordahl",
+      "display_name": "Gunnar Nordahl",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1246eb5b-dbb7-4065-a495-e0e6b5b6cac8"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kurt-hamrin",
+      "display_name": "Kurt Hamrin",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1246eb5b-dbb7-4065-a495-e0e6b5b6cac8"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "istvan-nyers",
+      "display_name": "István Nyers",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1246eb5b-dbb7-4065-a495-e0e6b5b6cac8"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "mauricio-pochettino",
+      "display_name": "Mauricio Pochettino",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8a8aaab2-a1aa-4985-b924-6cb6f7ca524d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "thiago-alcantara",
+      "display_name": "Thiago Alcântara",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "29311c68-029c-4446-b177-7ba2f196719e"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "city-ground",
+      "display_name": "City Ground",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c8bcde11-88d9-4068-8f22-12430437786b"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "bokelbergstadion",
+      "display_name": "Bökelbergstadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b74c9319-29f8-462c-80bd-989d41cf1ad9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mathias-pogba",
+      "display_name": "Mathias Pogba",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "83495ea3-0eee-4193-903d-27b83382e2bc"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "teddy-sheringham",
+      "display_name": "Teddy Sheringham",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "da0b7279-6909-488e-952b-ea4b4f5f5614"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "concacaf-gold-cup",
+      "display_name": "CONCACAF Gold Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6183fbaf-70cd-4888-896e-3f88222a25dd"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "su",
+      "display_name": "Soviet Union",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "32a685a2-4891-4705-b3ce-21811cf0ef1f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "giorgos-karagounis",
+      "display_name": "Giorgos Karagounis",
+      "aliases": [
+        "Karagounis"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "32807350-7ad5-489a-938a-9c950aeee1f0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "philipp-lahm",
+      "display_name": "Philipp Lahm",
+      "aliases": [
+        "Lahm"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8d7d2bf9-2289-49ab-83bc-9a989e126811"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "franz-beckenbauer",
+      "display_name": "Franz Beckenbauer",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c05ad81b-cbb6-4c34-92af-ca8622392c6d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "south-korea",
+      "display_name": "South Korea",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f2d8b1ee-d4ea-442f-861f-d13eb35b5494"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "parken-stadium",
+      "display_name": "Parken Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1679166c-6e98-4727-861e-9421ddeee591"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "otto-rehhagel",
+      "display_name": "Otto Rehhagel",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d131f65b-b780-42c9-b52e-9581ba6c44bf"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gianluca-vialli",
+      "display_name": "Gianluca Vialli",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "696ef1fe-28ad-4163-a872-ff9b46fc66a5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "youssef-el-arabi",
+      "display_name": "Youssef El Arabi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0b974789-205a-41ae-a675-21b5bdc24bd3"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mario-balotelli",
+      "display_name": "Mario Balotelli",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9595ac2b-27c8-41c0-9776-9dd739b642e4"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "vujadin-boskov",
+      "display_name": "Vujadin Boskov",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "07415ef3-da9a-4226-92e7-171681b4e44f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "hoffenheim",
+      "display_name": "Hoffenheim",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a02d5b6b-9958-4709-8f33-f1123fdaaddc"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "paulo-futre",
+      "display_name": "Paulo Futre",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9c6144b7-ae3f-4be6-8696-cb043c663ae1"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "tynecastle-park",
+      "display_name": "Tynecastle Park",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "14939893-6b5d-4c7a-9b5e-2717745ba327"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-do-maracana",
+      "display_name": "Estádio do Maracanã",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "abd2bd0c-cba4-4442-87f3-ea62bad877f7"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "skonto-riga",
+      "display_name": "Skonto Riga",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a53de3e6-c048-4233-81e7-23580f35ec18"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "lincoln-red-imps",
+      "display_name": "Lincoln Red Imps",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a53de3e6-c048-4233-81e7-23580f35ec18"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bate-borisov",
+      "display_name": "BATE Borisov",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a53de3e6-c048-4233-81e7-23580f35ec18"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "rosenborg",
+      "display_name": "Rosenborg",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a53de3e6-c048-4233-81e7-23580f35ec18"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "dinamo-zagreb",
+      "display_name": "Dinamo Zagreb",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a53de3e6-c048-4233-81e7-23580f35ec18"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "jupp-heynckes",
+      "display_name": "Jupp Heynckes",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8475005c-55e8-4b1c-8c8b-2ff8ca31c5b6"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "cliftonville",
+      "display_name": "Cliftonville FC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "eee1d8ec-a53c-4dd5-85d4-d51786825fc1"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "solitude",
+      "display_name": "Solitude",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "eee1d8ec-a53c-4dd5-85d4-d51786825fc1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "hibernian",
+      "display_name": "Hibernian",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "34db4e5f-2c0d-4c4d-9e68-3c22289ee661"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-do-bessa",
+      "display_name": "Estádio do Bessa",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f8d4b6b4-72c1-45a2-964a-f3ce588364a4"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "ivan-jovanovic",
+      "display_name": "Ivan Jovanović",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7cccba65-5715-4c4c-a393-30856d11ebcd"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "carlos-carvalhal",
+      "display_name": "Carlos Carvalhal",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7cccba65-5715-4c4c-a393-30856d11ebcd"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "jose-luis-mendilibar",
+      "display_name": "José Luis Mendilibar",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7cccba65-5715-4c4c-a393-30856d11ebcd"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "algeria",
+      "display_name": "Algeria",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "55837e6d-edce-4254-8a78-5914a150f37f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "james-milner",
+      "display_name": "James Milner",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2d4b0818-4569-415e-b06c-b8dda62081df"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gareth-barry",
+      "display_name": "Gareth Barry",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2d4b0818-4569-415e-b06c-b8dda62081df"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "david-james",
+      "display_name": "David James",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2d4b0818-4569-415e-b06c-b8dda62081df"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "stelios-giannakopoulos",
+      "display_name": "Stelios Giannakopoulos",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b4e0d20f-0884-4b45-b159-f1a5c8605ae0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "darren-anderton",
+      "display_name": "Darren Anderton",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5bdf66f4-7e8f-4526-9607-abd0b80071b2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "nolito",
+      "display_name": "Nolito",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9118070b-0a34-4426-a9ee-bfb61045df08"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "celta-vigo",
+      "display_name": "Celta Vigo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9118070b-0a34-4426-a9ee-bfb61045df08"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "otto-rehhagel",
+      "display_name": "Otto Rehhagel",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4f86c3c5-029e-4eed-95bc-4a63eeb81014"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "franco-baresi",
+      "display_name": "Franco Baresi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6a162ede-2c30-4dec-aa36-ceb9994753d1"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "vinicius-junior",
+      "display_name": "Vinicius Junior",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4e251099-d093-4b6a-a58f-fe42ebdbbb49"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "richarlison",
+      "display_name": "Richarlison",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4e251099-d093-4b6a-a58f-fe42ebdbbb49"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "pfk-ludogorets-razgrad",
+      "display_name": "PFK Ludogorets Razgrad",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2fa2facd-cda5-4adb-88e7-ae99f8596eda"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "huvepharma-arena",
+      "display_name": "Huvepharma Arena",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2fa2facd-cda5-4adb-88e7-ae99f8596eda"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "antony",
+      "display_name": "Antony",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "97d4b2a0-8c62-4507-bd80-ef5858c64796"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ru",
+      "display_name": "Russia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2b57c2a9-2758-402e-9d15-545d2ff8aa89"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ailton",
+      "display_name": "Ailton",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "af3cc0fc-ce33-4655-8432-f569d1c8a75f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ruben-perez",
+      "display_name": "Rubén Pérez",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "854c505a-3537-4c14-a795-c12a33d14c44"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "valerenga-fotball",
+      "display_name": "Vålerenga Fotball",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1e5637ff-87f4-4196-8b39-5e3792f29af6"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "intility-arena",
+      "display_name": "Intility Arena",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1e5637ff-87f4-4196-8b39-5e3792f29af6"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "ullevaal-stadion",
+      "display_name": "Ullevaal Stadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1e5637ff-87f4-4196-8b39-5e3792f29af6"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "frenkie-de-jong",
+      "display_name": "Frenkie de Jong",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d3c63983-71b0-425b-a84c-7f453fb5914c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "emmanuel-petit",
+      "display_name": "Emmanuel Petit",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9332f1e8-b75d-4183-a622-15b78a8b428f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "club-atletico-colon",
+      "display_name": "Club Atlético Colón",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "07138baf-0c0f-43e2-9ed6-601fb710f5ed"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-brigadier-general-estanislau-lopez",
+      "display_name": "Estadio Brigadier General Estanislao López",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "07138baf-0c0f-43e2-9ed6-601fb710f5ed"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "telmo-zarra",
+      "display_name": "Telmo Zarra",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7200f8e9-0ff0-4ee4-9d0f-daf1620aaf5b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "josep-samitier",
+      "display_name": "Josep Samitier",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7200f8e9-0ff0-4ee4-9d0f-daf1620aaf5b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "guillermo-gorostiza",
+      "display_name": "Guillermo Gorostiza",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7200f8e9-0ff0-4ee4-9d0f-daf1620aaf5b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "edmundo-suarez",
+      "display_name": "Edmundo Suárez",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7200f8e9-0ff0-4ee4-9d0f-daf1620aaf5b"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "arne-slot",
+      "display_name": "Arne Slot",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b8dd6713-1bc5-4bd2-bbf2-ef48b14a2761"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "utrecht",
+      "display_name": "Utrecht",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "86a53d23-13fc-439e-b380-1545c2c43729"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "hammarby-if",
+      "display_name": "Hammarby IF",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a5ac5d3d-2505-46d5-b156-c904e2491798"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "tele2-arena",
+      "display_name": "Tele2 Arena",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a5ac5d3d-2505-46d5-b156-c904e2491798"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "julio-cesar",
+      "display_name": "Júlio César",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b62948e0-fd79-43ba-8d7d-e265b6b16471"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alan-hansen",
+      "display_name": "Alan Hansen",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2de7fea0-fa2e-4e29-989e-9676a637a1f0"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "filippo-inzaghi",
+      "display_name": "Filippo Inzaghi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0e334f12-ec61-4ec4-a5f2-d0bac81bcad5"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "b36-torshavn",
+      "display_name": "B36 Tórshavn",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "434fb9e8-6e89-4974-b1e1-4530128738ed"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "gundadalur",
+      "display_name": "Gundadalur",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "434fb9e8-6e89-4974-b1e1-4530128738ed"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "faroe-islands-premier-league",
+      "display_name": "Faroe Islands Premier League",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "434fb9e8-6e89-4974-b1e1-4530128738ed"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "aik-fotboll",
+      "display_name": "AIK Fotboll",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ecbc8f14-3528-42f7-8a73-eca4e2e53e7c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "afc-bournemouth",
+      "display_name": "AFC Bournemouth",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "50f6b87e-24f8-4e45-9aa0-5598529b5d0a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "toronto-fc",
+      "display_name": "Toronto FC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "50f6b87e-24f8-4e45-9aa0-5598529b5d0a"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "max-eberl",
+      "display_name": "Max Eberl",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6889aaed-a458-4fe5-97d6-673fa21e96b2"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "uli-hoeness",
+      "display_name": "Uli Hoeness",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6889aaed-a458-4fe5-97d6-673fa21e96b2"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "southampton",
+      "display_name": "Southampton",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "41a00928-46a3-455a-a963-da7481bd0a5e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "paolo-rossi",
+      "display_name": "Paolo Rossi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7675fc6e-5dfe-4db8-a0ec-dc2ae334d613"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "lanerossi-vicenza",
+      "display_name": "Lanerossi Vicenza",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7675fc6e-5dfe-4db8-a0ec-dc2ae334d613"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "darren-bent",
+      "display_name": "Darren Bent",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "50f07e19-b233-4eb1-a323-d8903321d343"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-ciudad-de-valencia",
+      "display_name": "Estadio Ciudad de Valencia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6319f7bf-a4b9-46b0-a136-7cf2ec6efcf1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "levante-ud",
+      "display_name": "Levante UD",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6319f7bf-a4b9-46b0-a136-7cf2ec6efcf1"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "roger-piantoni",
+      "display_name": "Roger Piantoni",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ae0b9575-c8f1-4575-9f14-c7ba2556c573"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "de-meer-stadion",
+      "display_name": "De Meer Stadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e320c520-5e88-4088-ab2a-d7a6f6374d16"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "olympic-stadium",
+      "display_name": "Olympic Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e320c520-5e88-4088-ab2a-d7a6f6374d16"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "robbie-blake",
+      "display_name": "Robbie Blake",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a2d8ec90-dd11-477c-99d3-d9c2ca8e7432"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "burnley",
+      "display_name": "Burnley",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a2d8ec90-dd11-477c-99d3-d9c2ca8e7432"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "cristiano-giuntoli",
+      "display_name": "Cristiano Giuntoli",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "27fe0d2f-1bc3-46a4-8e8c-dd9d9457a890"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "aymeric-laporte",
+      "display_name": "Aymeric Laporte",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a52a1de5-f1fd-43f2-ac31-e2432dfe1dc7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dixie-dean",
+      "display_name": "Dixie Dean",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "639d4a22-1117-4905-8475-4833ec52493a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "joao-moutinho",
+      "display_name": "João Moutinho",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "16510146-5705-40e1-9b2e-a240ca1b6552"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dimitris-salpingidis",
+      "display_name": "Dimitris Salpingidis",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "16510146-5705-40e1-9b2e-a240ca1b6552"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "giuseppe-biava",
+      "display_name": "Giuseppe Biava",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "16510146-5705-40e1-9b2e-a240ca1b6552"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "daniel-carrico",
+      "display_name": "Daniel Carriço",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "16510146-5705-40e1-9b2e-a240ca1b6552"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "eric-black",
+      "display_name": "Eric Black",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cd491e0b-bf4e-40c3-a198-f1235fba6d56"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "john-hewitt",
+      "display_name": "John Hewitt",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cd491e0b-bf4e-40c3-a198-f1235fba6d56"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "juanito",
+      "display_name": "Juanito",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cd491e0b-bf4e-40c3-a198-f1235fba6d56"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "enzo-maresca",
+      "display_name": "Enzo Maresca",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cacab5aa-0987-4619-a32f-ebeaa7fea514"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "liam-rosenior",
+      "display_name": "Liam Rosenior",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cacab5aa-0987-4619-a32f-ebeaa7fea514"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "diego",
+      "display_name": "Diego",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b3d2e72e-920a-40e4-b174-111a73d6f287"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "arouna-kone",
+      "display_name": "Arouna Koné",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5cb78d6d-8731-42ca-8267-340b07e801aa"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "kf-vllaznia",
+      "display_name": "KF Vllaznia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "352b663b-cf15-4819-8097-7a2b6b9cd683"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "al",
+      "display_name": "Albania",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "352b663b-cf15-4819-8097-7a2b6b9cd683"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "michu",
+      "display_name": "Michu",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "14addb21-ccf4-459e-85c9-89f47b14e800"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "swansea-city",
+      "display_name": "Swansea City",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "14addb21-ccf4-459e-85c9-89f47b14e800"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ivan-de-la-pena",
+      "display_name": "Iván de la Peña",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "dfc8d044-af9b-44fe-a0de-dd27df0f0afc"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marcus-stewart",
+      "display_name": "Marcus Stewart",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5a10183b-a5c5-4a07-ac3a-7bbe1d60f08a"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "spanish-super-cup",
+      "display_name": "Spanish Super Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "771d2568-6295-45dc-acd0-7d64d7a10e9c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "graeme-sharp",
+      "display_name": "Graeme Sharp",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6bacae11-7dd0-4e40-b073-4cba8b0f8647"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "andy-gray",
+      "display_name": "Andy Gray",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6bacae11-7dd0-4e40-b073-4cba8b0f8647"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "neil-young",
+      "display_name": "Neil Young",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "54f71ad3-025a-4dbc-83a7-1c665dc458fc"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "harry-maguire",
+      "display_name": "Harry Maguire",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d60a9b2b-9f7e-497d-b9c1-c2d98530a178"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dieter-muller",
+      "display_name": "Dieter Müller",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f669a9de-531a-44c8-9ec9-1755b06b263d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ernst-willimowski",
+      "display_name": "Ernst Willimowski",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f669a9de-531a-44c8-9ec9-1755b06b263d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ernst-otto-laur",
+      "display_name": "Ernst-Otto Laur",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f669a9de-531a-44c8-9ec9-1755b06b263d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "luca-toni",
+      "display_name": "Luca Toni",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3d74ad2a-bec3-43b6-a155-ac9bf60b1f27"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jon-dahl-tomasson",
+      "display_name": "Jon Dahl Tomasson",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "eb2092df-8ccb-44ae-9057-cb6fdef42dc9"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sk-rapid-wien",
+      "display_name": "SK Rapid Wien",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7b2a2e92-066c-4667-bc75-691d7099527a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fk-austria-wien",
+      "display_name": "FK Austria Wien",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7b2a2e92-066c-4667-bc75-691d7099527a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "red-bull-salzburg",
+      "display_name": "Red Bull Salzburg",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7b2a2e92-066c-4667-bc75-691d7099527a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-wacker-innsbruck",
+      "display_name": "FC Wacker Innsbruck",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7b2a2e92-066c-4667-bc75-691d7099527a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "admira-wacker-modling",
+      "display_name": "Admira Wacker Mödling",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7b2a2e92-066c-4667-bc75-691d7099527a"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "austrian-bundesliga",
+      "display_name": "Austrian Bundesliga",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7b2a2e92-066c-4667-bc75-691d7099527a"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "veltins-arena",
+      "display_name": "Veltins-Arena",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ec0cbf37-5ce0-453b-b44b-5bc95d6dd6c5"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-st-pauli",
+      "display_name": "FC St. Pauli",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d12b1bee-5833-4986-86df-22b95b787df0"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "signal-iduna-park",
+      "display_name": "Signal Iduna Park",
+      "aliases": [
+        "Westfalenstadion"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e5e70e58-2d55-4845-b0ea-9db8aee7d877"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "maxwel-cornet",
+      "display_name": "Maxwel Cornet",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6aec5c73-bbcc-4d75-b97c-a7eabd70ba9a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "moussa-dembele",
+      "display_name": "Moussa Dembélé",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6aec5c73-bbcc-4d75-b97c-a7eabd70ba9a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "cagliari",
+      "display_name": "Cagliari",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "79e846be-7a22-4f08-b2e0-6155c2c05136"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "gimnasia-la-plata",
+      "display_name": "Gimnasia La Plata",
+      "aliases": [
+        "Gimnasia"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a7371555-f6ee-4138-aa48-8576d63d404c"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadi-olimpic-lluis-companys",
+      "display_name": "Estadi Olímpic Lluís Companys",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b86941de-9fd2-4eb8-9d79-f14678c40d5c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marek-mintal",
+      "display_name": "Marek Mintál",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "76a2e61a-49bb-490b-8702-d279fca85dca"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "1-fc-nurnberg",
+      "display_name": "1. FC Nürnberg",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "76a2e61a-49bb-490b-8702-d279fca85dca"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ronaldo-nazario",
+      "display_name": "Ronaldo Nazário",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "23c5e8e3-cb64-47b4-9c0c-6b3c41fa48f4"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "english-league-cup",
+      "display_name": "English League Cup",
+      "aliases": [
+        "Carabao Cup"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "156d53f0-06a3-40fd-b3b8-c93edbd7307a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "switzerland",
+      "display_name": "Switzerland",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ba5412d8-f911-4223-9496-ede6a1431f93"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "angel-di-maria",
+      "display_name": "Ángel Di María",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ba5412d8-f911-4223-9496-ede6a1431f93"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "hans-dieter-flick",
+      "display_name": "Hans-Dieter Flick",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "dbfd8cb5-3fce-4b36-b852-9fed4780e61e"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "kieran-mckenna",
+      "display_name": "Kieran McKenna",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c65aec41-e74f-4db7-afdb-62ddffa55165"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "kansas-city-chiefs",
+      "display_name": "Kansas City Chiefs",
+      "aliases": [
+        "Chiefs"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "47ac7af9-86f8-461d-a9d4-cfaddb6c0daa"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "philadelphia-eagles",
+      "display_name": "Philadelphia Eagles",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "47ac7af9-86f8-461d-a9d4-cfaddb6c0daa"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alan-sunderland",
+      "display_name": "Alan Sunderland",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "802ccd77-91cf-4411-b741-b5bb5687026f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "brian-talbot",
+      "display_name": "Brian Talbot",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "802ccd77-91cf-4411-b741-b5bb5687026f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "frank-stapleton",
+      "display_name": "Frank Stapleton",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "802ccd77-91cf-4411-b741-b5bb5687026f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gordon-mcqueen",
+      "display_name": "Gordon McQueen",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "802ccd77-91cf-4411-b741-b5bb5687026f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "sammy-mcilroy",
+      "display_name": "Sammy McIlroy",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "802ccd77-91cf-4411-b741-b5bb5687026f"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "groupama-arena",
+      "display_name": "Groupama Aréna",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d28c7ca0-f4bc-4bb0-8a16-cbb8aac16a74"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "roda-jc",
+      "display_name": "Roda JC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f21e6ed0-1de0-4317-96d0-2c38891e31e9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "willie-wallace",
+      "display_name": "Willie Wallace",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1d063fd6-0034-4b3c-8067-346ae4aa49b5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "grant-holt",
+      "display_name": "Grant Holt",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7cebf1c5-5d6e-47d8-a8e9-b9d00b454023"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "hampden-park",
+      "display_name": "Hampden Park",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "073ce170-5f72-48cd-8151-34cfed1942d4"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "neckarstadion",
+      "display_name": "Neckarstadion",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "073ce170-5f72-48cd-8151-34cfed1942d4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mido",
+      "display_name": "Mido",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "beac0793-3219-4c65-bc45-55736c17f094"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "ullevi",
+      "display_name": "Ullevi",
+      "aliases": [
+        "Nya Ullevi"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "54d3dcf9-8542-4892-856c-9d4f136c6c61"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alexandre-lacazette",
+      "display_name": "Alexandre Lacazette",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fcd3a0e8-583c-4c14-b8f3-b2e61c21bb4f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "corentin-tolisso",
+      "display_name": "Corentin Tolisso",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fcd3a0e8-583c-4c14-b8f3-b2e61c21bb4f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marco-negri",
+      "display_name": "Marco Negri",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a1c1a80e-1c1d-4497-ae5c-1c3429421403"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "tony-cottee",
+      "display_name": "Tony Cottee",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "efee809d-0cb3-4f99-a6e6-b09c7852854b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "antoine-griezmann",
+      "display_name": "Antoine Griezmann",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "df6cc097-1426-4f66-a2ae-bfa4411ae46a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "orlando-city",
+      "display_name": "Orlando City",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "df6cc097-1426-4f66-a2ae-bfa4411ae46a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fc-utrecht",
+      "display_name": "FC Utrecht",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fe22e6c8-75b1-4780-8c96-127bbf75865b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "carlos-tevez",
+      "display_name": "Carlos Tévez",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "dd540254-3125-4995-aee9-04ea352d09f1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "vasas-sc",
+      "display_name": "Vasas SC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fad00224-4313-4dec-a38e-f532567fee6f"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "mitropa-cup",
+      "display_name": "Mitropa Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fad00224-4313-4dec-a38e-f532567fee6f"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "illovszky-rudolf-stadion",
+      "display_name": "Illovszky Rudolf Stadion",
+      "aliases": [
+        "Fáy utcai Stadion"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fad00224-4313-4dec-a38e-f532567fee6f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "soviet-union",
+      "display_name": "Soviet Union",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8fd81dc1-7c41-4056-a98d-2009d7b3c44a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "herbert-wimmer",
+      "display_name": "Herbert Wimmer",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8fd81dc1-7c41-4056-a98d-2009d7b3c44a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "rafael-van-der-vaart",
+      "display_name": "Rafael van der Vaart",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "94b2101a-9d26-465f-8242-33d8f99f8d8c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ud-las-palmas",
+      "display_name": "UD Las Palmas",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5d07dd72-62f3-4d10-91d8-b69c5554a7a1"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-gran-canaria",
+      "display_name": "Estadio Gran Canaria",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5d07dd72-62f3-4d10-91d8-b69c5554a7a1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "racing-club",
+      "display_name": "Racing Club",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7ebc9dc0-4cd2-440a-807e-ce42d8ea89cd"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "intercontinental-cup",
+      "display_name": "Intercontinental Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7ebc9dc0-4cd2-440a-807e-ce42d8ea89cd"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "friaca",
+      "display_name": "Friaça",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9b4e02bc-b1bd-4430-ba59-d27968440ac3"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "juan-alberto-schiaffino",
+      "display_name": "Juan Alberto Schiaffino",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9b4e02bc-b1bd-4430-ba59-d27968440ac3"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "alcides-ghiggia",
+      "display_name": "Alcides Ghiggia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9b4e02bc-b1bd-4430-ba59-d27968440ac3"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "youri-djorkaeff",
+      "display_name": "Youri Djorkaeff",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9ec67769-b29b-4299-bcb7-94b013e7e6cd"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "brian-laudrup",
+      "display_name": "Brian Laudrup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d5725e72-c593-469b-9388-dc73d643cbb9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "michael-laudrup",
+      "display_name": "Michael Laudrup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d5725e72-c593-469b-9388-dc73d643cbb9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "giuseppe-signori",
+      "display_name": "Giuseppe Signori",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "29962a43-0d83-4821-aed2-0fd8078770cc"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "capocannoniere",
+      "display_name": "Capocannoniere",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "29962a43-0d83-4821-aed2-0fd8078770cc"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "djimi-traore",
+      "display_name": "Djimi Traoré",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1c8c5755-262e-4013-adcd-ac5612e6dd63"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "fabio-capello",
+      "display_name": "Fabio Capello",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "723d1bf3-4d38-4af2-980b-ef8e97d7f50c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "genoa",
+      "display_name": "Genoa",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "caf5122a-d21e-451b-9910-d8729e949098"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "javier-saviola",
+      "display_name": "Javier Saviola",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c37e7413-a3ee-4599-ba45-6afa9afc1668"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "nigel-martyn",
+      "display_name": "Nigel Martyn",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0fa83543-b616-4e37-aedf-823f3260571b"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "santiago-bernabeu",
+      "display_name": "Santiago Bernabéu",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0de86b5f-3aba-4b02-80cc-2be497af288f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jurgen-kohler",
+      "display_name": "Jürgen Kohler",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "58f60c7d-88fa-4da7-bdf1-c95243be7faa"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "de-grolsch-veste",
+      "display_name": "De Grolsch Veste",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9f496f34-24e9-42ba-98b5-fb2ff26b14ac"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "fa-charity-shield",
+      "display_name": "FA Charity Shield",
+      "aliases": [
+        "Community Shield"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3447d906-f0bc-40e2-ae8e-956caf6889b8"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "partizan-belgrade",
+      "display_name": "Partizan Belgrade",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "19076705-9a1c-406f-be7c-c738f474aa41"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "partizan-stadium",
+      "display_name": "Partizan Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "19076705-9a1c-406f-be7c-c738f474aa41"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-ciudad-de-vicente-lopez",
+      "display_name": "Estadio Ciudad de Vicente López",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ced85fce-c395-45e4-a53a-89c0191b6b39"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "club-atletico-platense",
+      "display_name": "Club Atlético Platense",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ced85fce-c395-45e4-a53a-89c0191b6b39"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "hill-dickinson-stadium",
+      "display_name": "Hill Dickinson Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cc39e944-9869-42a3-b1a7-5adefe278a0f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "senegal",
+      "display_name": "Senegal",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4b561d55-5010-4faa-a5f7-da058f1d1c21"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marcel-ruiz",
+      "display_name": "Marcel Ruiz",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4bc631bb-f78e-4c4b-9168-9e862db636ca"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "liga-mx",
+      "display_name": "Liga MX",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4bc631bb-f78e-4c4b-9168-9e862db636ca"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "toluca",
+      "display_name": "Toluca",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4bc631bb-f78e-4c4b-9168-9e862db636ca"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ogc-nice",
+      "display_name": "OGC Nice",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4bc631bb-f78e-4c4b-9168-9e862db636ca"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "palmeiras",
+      "display_name": "Palmeiras",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4bc631bb-f78e-4c4b-9168-9e862db636ca"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "goncalo-ramos",
+      "display_name": "Gonçalo Ramos",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "73a6b746-c1f6-4903-b722-16bceec3919c"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "simone-inzaghi",
+      "display_name": "Simone Inzaghi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "da62d2f0-21bf-45fb-9ede-dfb95ab47bf5"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "frank-lampard",
+      "display_name": "Frank Lampard",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3dde25b5-efe4-4425-aa4e-8e32993a82ca"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "igor-tudor",
+      "display_name": "Igor Tudor",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "95e88a75-3b9e-44f5-82e8-a2977d27aa2e"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "thomas-frank",
+      "display_name": "Thomas Frank",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "95e88a75-3b9e-44f5-82e8-a2977d27aa2e"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "energie-cottbus",
+      "display_name": "Energie Cottbus",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ab7a3108-aa23-4c2d-9b02-4a8ecb2dc2d9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "giovane-elber",
+      "display_name": "Giovane Élber",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ab7a3108-aa23-4c2d-9b02-4a8ecb2dc2d9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "milan-baros",
+      "display_name": "Milan Baroš",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "160445c8-e54e-4dae-9716-3cd766e12a61"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "banik-ostrava",
+      "display_name": "Baník Ostrava",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "160445c8-e54e-4dae-9716-3cd766e12a61"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "al-nassr",
+      "display_name": "Al-Nassr",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3f372638-d56b-45eb-aca2-444690340c4c"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "valeriy-lobanovskyi",
+      "display_name": "Valeriy Lobanovskyi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "dfd055cd-727a-4ebf-a086-b141ebe9a743"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dragan-dzajic",
+      "display_name": "Dragan Džajić",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a0cb5247-f106-4786-954e-033d5d1c72ea"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "tony-cascarino",
+      "display_name": "Tony Cascarino",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6ff15d52-e08f-4922-a917-ca3ac3e560f8"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "ligue-2",
+      "display_name": "Ligue 2",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "6ff15d52-e08f-4922-a917-ca3ac3e560f8"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "cska-sofia",
+      "display_name": "CSKA Sofia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "274a5c64-e7cd-40df-9ad6-24be1e95dd4d"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "in",
+      "display_name": "India",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "274a5c64-e7cd-40df-9ad6-24be1e95dd4d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "juan-pablo-angel",
+      "display_name": "Juan Pablo Ángel",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9e476a7e-7a2e-429b-820b-49cab7c434de"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "divock-origi",
+      "display_name": "Divock Origi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2a71a58a-ed5d-436b-baa1-b5a54c22fe36"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "attilio-lombardo",
+      "display_name": "Attilio Lombardo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "49bd4502-7688-404d-b070-916b42fc728e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "klaas-jan-huntelaar",
+      "display_name": "Klaas-Jan Huntelaar",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f5928327-a4e8-4f8d-a55c-d7ee01485e07"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadion-miejski-wroclaw",
+      "display_name": "Stadion Miejski",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7eb53d78-b6eb-46d6-9df2-d3f56b65929d"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "stefano-pioli",
+      "display_name": "Stefano Pioli",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3e9a0d2a-60e6-4382-ba77-d595e6574b50"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "sergio-conceicao",
+      "display_name": "Sergio Conceicao",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3e9a0d2a-60e6-4382-ba77-d595e6574b50"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "roy-keane",
+      "display_name": "Roy Keane",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "23d9132b-3922-412d-954a-f8d9bfba881e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "david-de-gea",
+      "display_name": "David De Gea",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "23d9132b-3922-412d-954a-f8d9bfba881e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jack-wilshere",
+      "display_name": "Jack Wilshere",
+      "aliases": [
+        "Jack Wilshere"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "23d9132b-3922-412d-954a-f8d9bfba881e"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "elland-road",
+      "display_name": "Elland Road",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "23540058-c46d-4303-9689-ee72a9f7fe58"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "park-ji-sung",
+      "display_name": "Park Ji-sung",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "296dabf7-0cb1-4e5b-9cad-73a9e530c382"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "kyoto-purple-sanga",
+      "display_name": "Kyoto Purple Sanga",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "296dabf7-0cb1-4e5b-9cad-73a9e530c382"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "fernando-peyroteo",
+      "display_name": "Fernando Peyroteo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "889631dc-89e7-4e0a-8e6f-051b78042bb7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "rogerio-carvalho",
+      "display_name": "Rogério Carvalho",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "889631dc-89e7-4e0a-8e6f-051b78042bb7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jose-aguas",
+      "display_name": "José Águas",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "889631dc-89e7-4e0a-8e6f-051b78042bb7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "arsenio-duarte",
+      "display_name": "Arsénio Duarte",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "889631dc-89e7-4e0a-8e6f-051b78042bb7"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "predrag-mijatovic",
+      "display_name": "Predrag Mijatović",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "912bd185-2618-4a28-bde4-3b9dc0f706d9"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "luciano-spalletti",
+      "display_name": "Luciano Spalletti",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4f07fa20-e1a2-4b89-9330-3f3c35f1e490"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "san-lorenzo",
+      "display_name": "San Lorenzo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9135a2d7-c2c4-4621-b700-4d60eeb50037"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "hull-city",
+      "display_name": "Hull City",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8dd6b914-1e36-4ddc-b0f9-4aa0653a09ec"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "james-chester",
+      "display_name": "James Chester",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8dd6b914-1e36-4ddc-b0f9-4aa0653a09ec"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "curtis-davies",
+      "display_name": "Curtis Davies",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8dd6b914-1e36-4ddc-b0f9-4aa0653a09ec"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "santi-cazorla",
+      "display_name": "Santi Cazorla",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8dd6b914-1e36-4ddc-b0f9-4aa0653a09ec"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "laurent-koscielny",
+      "display_name": "Laurent Koscielny",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8dd6b914-1e36-4ddc-b0f9-4aa0653a09ec"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "aaron-ramsey",
+      "display_name": "Aaron Ramsey",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8dd6b914-1e36-4ddc-b0f9-4aa0653a09ec"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "gb-wls",
+      "display_name": "Wales",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b1caea05-9834-4f2a-9eeb-0fbdf168a9da"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ronald-koeman",
+      "display_name": "Ronald Koeman",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "80002466-a961-4c84-8d90-868ac327f807"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "roger",
+      "display_name": "Roger",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "80002466-a961-4c84-8d90-868ac327f807"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "bastian-schweinsteiger",
+      "display_name": "Bastian Schweinsteiger",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "03c38b3b-6789-4aa3-945c-42c9ef02129d"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "belgian-pro-league",
+      "display_name": "Belgian Pro League",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5a47661b-b83b-4cf1-9241-9cee351493a4"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "jan-breydel-stadium",
+      "display_name": "Jan Breydel Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5a47661b-b83b-4cf1-9241-9cee351493a4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "fred",
+      "display_name": "Fred",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "125badf2-fd52-4221-b6d5-47351132e69f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "luis-garcia",
+      "display_name": "Luis García",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "261aaa65-a8a1-42c5-a749-ff7306150e2c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "terry-mcdermott",
+      "display_name": "Terry McDermott",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "87200de5-1efb-4b90-ab3c-793073542d97"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "david-fairclough",
+      "display_name": "David Fairclough",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "87200de5-1efb-4b90-ab3c-793073542d97"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "rob-rensenbrink",
+      "display_name": "Rob Rensenbrink",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "87200de5-1efb-4b90-ab3c-793073542d97"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "francois-van-der-elst",
+      "display_name": "François Van der Elst",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "87200de5-1efb-4b90-ab3c-793073542d97"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "arie-haan",
+      "display_name": "Arie Haan",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "87200de5-1efb-4b90-ab3c-793073542d97"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "frank-rijkaard",
+      "display_name": "Frank Rijkaard",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "87200de5-1efb-4b90-ab3c-793073542d97"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mark-hateley",
+      "display_name": "Mark Hateley",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2e1f4d4a-bb77-480d-b08c-333dae48ccdd"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "independiente",
+      "display_name": "Independiente",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ca4cbc71-5374-4c31-a70a-61d039334cd3"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadion-zimbru",
+      "display_name": "Stadion Zimbru",
+      "aliases": [
+        "Stadionul Zimbru"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b5ab9b45-8723-4395-b095-ae737b409eb6"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "zimbru-chisinau",
+      "display_name": "FC Zimbru Chișinău",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b5ab9b45-8723-4395-b095-ae737b409eb6"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "md",
+      "display_name": "Moldova",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b5ab9b45-8723-4395-b095-ae737b409eb6"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "eidur-gudjohnsen",
+      "display_name": "Eidur Guðjohnsen",
+      "aliases": [
+        "Eiður Guðjohnsen"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8aa07a7d-4fb2-474a-ab3c-98ea2ff688f3"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "nac-breda",
+      "display_name": "NAC Breda",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ca0d5fcc-776c-46bb-ba48-7cfff08964ae"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "belgian-cup",
+      "display_name": "Belgian Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "da983271-dbc2-43dc-b95a-506687f82ebc"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "beerschot-vac",
+      "display_name": "K. Beerschot V.A.C.",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "da983271-dbc2-43dc-b95a-506687f82ebc"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "us-salernitana-1919",
+      "display_name": "US Salernitana 1919",
+      "aliases": [
+        "Salernitana"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e45191d0-d812-4023-8fec-7fc7de0e5721"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "morocco",
+      "display_name": "Morocco",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "839c81f3-3980-4176-8a57-e9e89050d102"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "scottish-league-cup",
+      "display_name": "Scottish League Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "31605baa-ae78-4f02-a8c7-9e91b0afaf93"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "scottish-premier-division",
+      "display_name": "Scottish Premier Division",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "31605baa-ae78-4f02-a8c7-9e91b0afaf93"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "nacional",
+      "display_name": "Nacional",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2f78c9ca-0ce3-48a7-9436-145f06d43741"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "waldemar-victorino",
+      "display_name": "Waldemar Victorino",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2f78c9ca-0ce3-48a7-9436-145f06d43741"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "al-ahly",
+      "display_name": "Al Ahly",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "51a186e9-dcf8-434a-b4e0-6fa242f78d45"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "zamalek",
+      "display_name": "Zamalek",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "51a186e9-dcf8-434a-b4e0-6fa242f78d45"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "tp-mazembe",
+      "display_name": "TP Mazembe",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "51a186e9-dcf8-434a-b4e0-6fa242f78d45"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "esperance-de-tunis",
+      "display_name": "Espérance de Tunis",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "51a186e9-dcf8-434a-b4e0-6fa242f78d45"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "wydad-ac",
+      "display_name": "Wydad AC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "51a186e9-dcf8-434a-b4e0-6fa242f78d45"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "caf-champions-league",
+      "display_name": "African Champions League",
+      "aliases": [
+        "CAF Champions League"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "51a186e9-dcf8-434a-b4e0-6fa242f78d45"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "bruno-fernandes",
+      "display_name": "Bruno Fernandes",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "61cd15c4-cad8-43a2-bc20-f1bf6bfe5095"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "tanguy-ndombele",
+      "display_name": "Tanguy Ndombele",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "61cd15c4-cad8-43a2-bc20-f1bf6bfe5095"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "son-heung-min",
+      "display_name": "Son Heung-min",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "61cd15c4-cad8-43a2-bc20-f1bf6bfe5095"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "anthony-martial",
+      "display_name": "Anthony Martial",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "61cd15c4-cad8-43a2-bc20-f1bf6bfe5095"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "serge-aurier",
+      "display_name": "Serge Aurier",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "61cd15c4-cad8-43a2-bc20-f1bf6bfe5095"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "us-livorno-1915",
+      "display_name": "US Livorno 1915",
+      "aliases": [
+        "A.S. Livorno Calcio"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fac6f6fc-76da-4d72-9d1a-1fd20f372189"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadio-armando-picchi",
+      "display_name": "Stadio Armando Picchi",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fac6f6fc-76da-4d72-9d1a-1fd20f372189"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "serie-d",
+      "display_name": "Serie D",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fac6f6fc-76da-4d72-9d1a-1fd20f372189"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "serie-c",
+      "display_name": "Serie C",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fac6f6fc-76da-4d72-9d1a-1fd20f372189"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "pittodrie-stadium",
+      "display_name": "Pittodrie Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ce91e532-d78c-480e-a58c-9e609f59af0a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "romelu-lukaku",
+      "display_name": "Romelu Lukaku",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "93d05043-ffc8-488e-abd5-cae3d4f08d94"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "stuart-beedie",
+      "display_name": "Stuart Beedie",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a699203b-f87d-4352-9168-753b0a9bb388"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "davie-provan",
+      "display_name": "Davie Provan",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a699203b-f87d-4352-9168-753b0a9bb388"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "frank-mcgarvey",
+      "display_name": "Frank McGarvey",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a699203b-f87d-4352-9168-753b0a9bb388"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "laurent-leroy",
+      "display_name": "Laurent Leroy",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f84745bd-de92-42bd-89e0-8b990ae6bdf4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "walter-pandiani",
+      "display_name": "Walter Pandiani",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f84745bd-de92-42bd-89e0-8b990ae6bdf4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "diego-tristan",
+      "display_name": "Diego Tristán",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f84745bd-de92-42bd-89e0-8b990ae6bdf4"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-womens-championship",
+      "display_name": "UEFA Women's Championship",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a7c0f649-285e-4a18-a6a1-f7aca4a6ba53"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "friends-arena",
+      "display_name": "Friends Arena",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a7c0f649-285e-4a18-a6a1-f7aca4a6ba53"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "matias-almeyda",
+      "display_name": "Matías Almeyda",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f5878be-683b-4d32-aaea-33a86245de31"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "alaves",
+      "display_name": "Alavés",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f5878be-683b-4d32-aaea-33a86245de31"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "pedri",
+      "display_name": "Pedri",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5fec9703-d3fe-4ef5-b88b-7fa833177253"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "stade-rennais",
+      "display_name": "Stade Rennais",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "58a3faba-8b46-407b-bf8b-1ba9e2d8ff2e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "florian-wirtz",
+      "display_name": "Florian Wirtz",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "863cc7be-664c-43da-ad2c-4a875c634871"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "raphinha",
+      "display_name": "Raphinha",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "627d2930-394e-4140-b64a-2ae9f2a6315f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "michael-olise",
+      "display_name": "Michael Olise",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "edae569f-13a8-4549-af8c-a2ef748c896e"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marco-di-vaio",
+      "display_name": "Marco Di Vaio",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c95ea321-a5f1-4430-9c88-608f30cccd88"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "john-hartson",
+      "display_name": "John Hartson",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "02ce1430-6b83-4949-a064-cc58422dcbd1"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "coventry-city",
+      "display_name": "Coventry City",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "02ce1430-6b83-4949-a064-cc58422dcbd1"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "fifa-confederations-cup",
+      "display_name": "FIFA Confederations Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "020faf1d-cdb6-482b-815f-cb0ff0d8be68"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ally-mccoist",
+      "display_name": "Ally McCoist",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3ac9fdd2-793a-4d0a-bd63-44eb12257dde"
+      ]
+    },
+    {
+      "type": "league",
+      "slug": "scottish-premier-division",
+      "display_name": "Scottish Premier Division",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3ac9fdd2-793a-4d0a-bd63-44eb12257dde"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "inter-cities-fairs-cup",
+      "display_name": "Inter-Cities Fairs Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "99cc1801-4186-49c1-9635-b69f3a22c44b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "allan-clarke",
+      "display_name": "Allan Clarke",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d0e18372-e7a3-4124-9746-ea8ad66d8893"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "dusan-vlahovic",
+      "display_name": "Dusan Vlahovic",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "03250a5a-8c1f-4d12-b816-10636ac06261"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "clermont-foot-63",
+      "display_name": "Clermont Foot 63",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5a4efc0b-c4a1-4004-a320-4355e98407e5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "paolo-di-canio",
+      "display_name": "Paolo Di Canio",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "562b0cb1-87cf-4e4b-960f-84c50c33ae73"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "shamrock-rovers",
+      "display_name": "Shamrock Rovers",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4a561e5a-4e1d-468b-927d-4bff71b03281"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "tallaght-stadium",
+      "display_name": "Tallaght Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4a561e5a-4e1d-468b-927d-4bff71b03281"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "lothar-matthaus",
+      "display_name": "Lothar Matthäus",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2a273292-178c-4336-b79a-07e437db7c48"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "rsc-olimpiyskiy",
+      "display_name": "RSC Olimpiyskiy",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "33e333aa-9a2f-490a-a14a-4c310455d5f5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "daniel-podence",
+      "display_name": "Daniel Podence",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4db65797-8613-4d71-81e7-fd1272541843"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "kostas-fortounis",
+      "display_name": "Kostas Fortounis",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4db65797-8613-4d71-81e7-fd1272541843"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "nwankwo-kanu",
+      "display_name": "Nwankwo Kanu",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "d7e97156-c840-459a-933a-7737ebda28aa"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "uefa-nations-league",
+      "display_name": "UEFA Nations League",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "42e66378-29ec-405e-a91d-7f4d6b702a06"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "arsene-wenger",
+      "display_name": "Arsène Wenger",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f2e0da23-2758-4fa4-ab11-003b32c9c958"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "pohang-steelers",
+      "display_name": "Pohang Steelers",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "83437758-5b21-44e0-b60f-448defc8c301"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "urawa-red-diamonds",
+      "display_name": "Urawa Red Diamonds",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "83437758-5b21-44e0-b60f-448defc8c301"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "jeonbuk-hyundai-motors",
+      "display_name": "Jeonbuk Hyundai Motors",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "83437758-5b21-44e0-b60f-448defc8c301"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "valere-germain",
+      "display_name": "Valère Germain",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "a86fac6f-8370-4535-86a7-a06fa13773a8"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stade-geoffroy-guichard",
+      "display_name": "Stade Geoffroy-Guichard",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7667cf3a-9529-460e-9367-efde2aedeceb"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "craig-bellamy",
+      "display_name": "Craig Bellamy",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "3df17aff-ed8b-43a1-89ff-e946c4e5890b"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "nigel-spink",
+      "display_name": "Nigel Spink",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b098f80c-9122-48b4-b4de-488d1398be2c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jimmy-rimmer",
+      "display_name": "Jimmy Rimmer",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "b098f80c-9122-48b4-b4de-488d1398be2c"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jermaine-jenas",
+      "display_name": "Jermaine Jenas",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bbcdeaba-3119-49df-9ebc-ff78317dcbc8"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marcel-desailly",
+      "display_name": "Marcel Desailly",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bf045da1-b076-4ce5-a7f7-aaa0b2b4c16a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "aurelien-tchouameni",
+      "display_name": "Aurélien Tchouaméni",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bc8ee7aa-7cdd-49a3-ba68-5ff4a0f88bb6"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "mechelen",
+      "display_name": "Mechelen",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "66b73390-51d2-4eba-bb9a-0a6eaa7e0444"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "aad-de-mos",
+      "display_name": "Aad de Mos",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "66b73390-51d2-4eba-bb9a-0a6eaa7e0444"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "union-saint-gilloise",
+      "display_name": "Union Saint-Gilloise",
+      "aliases": [
+        "Royale Union Saint-Gilloise"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "2f0d5448-42f0-4dbf-a26e-d07541eccdbf"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "franck-ribery",
+      "display_name": "Franck Ribéry",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9ce64aee-a0c4-456a-8674-b2aaf723edd4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "marco-reus",
+      "display_name": "Marco Reus",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9ce64aee-a0c4-456a-8674-b2aaf723edd4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "andreas-moller",
+      "display_name": "Andreas Möller",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9ce64aee-a0c4-456a-8674-b2aaf723edd4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ze-roberto",
+      "display_name": "Zé Roberto",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "9ce64aee-a0c4-456a-8674-b2aaf723edd4"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "gabriel-jesus",
+      "display_name": "Gabriel Jesus",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c7778f89-d7eb-41b6-992b-9f920d08ceed"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "mikel-arteta",
+      "display_name": "Mikel Arteta",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "c7778f89-d7eb-41b6-992b-9f920d08ceed"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jordi-alba",
+      "display_name": "Jordi Alba",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "1179a2d7-8a01-43ae-bbfb-a88affdd8600"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "feyenoord-rotterdam",
+      "display_name": "Feyenoord Rotterdam",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "79ff080c-0f19-4e26-a364-095bb71b5594"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "la-bombonera",
+      "display_name": "La Bombonera",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "bf9df7dd-bc40-41c2-a78c-a77cd7dc466d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "mats-hummels",
+      "display_name": "Mats Hummels",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "10cddef9-881e-4ab7-8302-4fd838986bb9"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jose-altafini",
+      "display_name": "José Altafini",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "14dc135f-0a1f-4f0d-9c5a-69855f0837f6"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "osasuna",
+      "display_name": "Osasuna",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "72b5256e-a911-4f95-a9a4-2995844a50d5"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "flamengo",
+      "display_name": "Flamengo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fce8657c-5cd2-4adb-9d31-9ff27e9891ff"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "copa-do-brasil",
+      "display_name": "Copa do Brasil",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fce8657c-5cd2-4adb-9d31-9ff27e9891ff"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "atletico-paranaense",
+      "display_name": "Atlético Paranaense",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "fce8657c-5cd2-4adb-9d31-9ff27e9891ff"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "jupp-heynckes",
+      "display_name": "Jupp Heynckes",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5fa26817-0f16-4662-8f0c-3a92a015964d"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "sergio-busquets",
+      "display_name": "Sergio Busquets",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f443ee0-aac5-48de-9e74-0d5dcbce3bd5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "sergio-ramos",
+      "display_name": "Sergio Ramos",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f443ee0-aac5-48de-9e74-0d5dcbce3bd5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "manuel-sanchis",
+      "display_name": "Manuel Sanchís",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f443ee0-aac5-48de-9e74-0d5dcbce3bd5"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "paco-gento",
+      "display_name": "Paco Gento",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f443ee0-aac5-48de-9e74-0d5dcbce3bd5"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ruch-chorzow",
+      "display_name": "Ruch Chorzów",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ca4da946-a289-4f34-8c57-700fed4fe7bb"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadion-miejski-w-chorzowie",
+      "display_name": "Stadion Miejski w Chorzowie",
+      "aliases": [
+        "Ruch Chorzów Stadium"
+      ],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ca4da946-a289-4f34-8c57-700fed4fe7bb"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "wiener-sport-club",
+      "display_name": "Wiener Sport-Club",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "15d25ac5-1dad-478a-b522-9c3cb224f54f"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "sportclub-platz",
+      "display_name": "Sportclub-Platz",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "15d25ac5-1dad-478a-b522-9c3cb224f54f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "bohemians-1905",
+      "display_name": "Bohemians 1905",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cd3532c9-3655-48a7-b869-1f48bd226568"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "dolicek",
+      "display_name": "Ďolíček",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "cd3532c9-3655-48a7-b869-1f48bd226568"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "hazza-bin-zayed-stadium",
+      "display_name": "Hazza Bin Zayed Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "66949d31-27ff-4458-9a6a-dbe079bc0495"
+      ]
+    },
+    {
+      "type": "country",
+      "slug": "ae",
+      "display_name": "United Arab Emirates",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "66949d31-27ff-4458-9a6a-dbe079bc0495"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "al-ain-fc",
+      "display_name": "Al Ain FC",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "66949d31-27ff-4458-9a6a-dbe079bc0495"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "etihad-stadium",
+      "display_name": "Etihad Stadium",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "590c3df5-223b-4727-910d-aa1f7a02e8a6"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "fernandinho",
+      "display_name": "Fernandinho",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "590c3df5-223b-4727-910d-aa1f7a02e8a6"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "goodison-park",
+      "display_name": "Goodison Park",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "5b9511ad-0018-4b27-84e4-ae6da8beea20"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "villa-park",
+      "display_name": "Villa Park",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7849383c-3815-4df6-8e43-5d363b14615c"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "colombia",
+      "display_name": "Colombia",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "8f6f4285-34c5-41fa-a510-14c68a88399d"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "lokomotiv-moscow",
+      "display_name": "Lokomotiv Moscow",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4b10c27a-1bb0-484b-9c51-02609273af0f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "zenit-st-petersburg",
+      "display_name": "Zenit St. Petersburg",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4b10c27a-1bb0-484b-9c51-02609273af0f"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "dynamo-moscow",
+      "display_name": "Dynamo Moscow",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "4b10c27a-1bb0-484b-9c51-02609273af0f"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "pierre-emerick-aubameyang",
+      "display_name": "Pierre-Emerick Aubameyang",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f78b8365-43eb-4197-a174-407be922ef88"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ante-rebic",
+      "display_name": "Ante Rebić",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "f78b8365-43eb-4197-a174-407be922ef88"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "ghana",
+      "display_name": "Ghana",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "338d0e0e-2272-4a96-85ef-a081f71f9874"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "horst-hrubesch",
+      "display_name": "Horst Hrubesch",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "24a149fb-a7c4-4154-b0cf-3a1c13e5488f"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "national-stadium-warsaw",
+      "display_name": "National Stadium, Warsaw",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "547a852b-af95-4821-b6e9-3c245a9155a6"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "dnipro-dnipropetrovsk",
+      "display_name": "Dnipro Dnipropetrovsk",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "547a852b-af95-4821-b6e9-3c245a9155a6"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stade-de-france",
+      "display_name": "Stade de France",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "7e38b049-50d3-4887-bcbc-69b30318ed93"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "puskas-arena",
+      "display_name": "Puskás Aréna",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "949984af-dcee-4f36-9f71-183d353d6b22"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "ferenc-puskas",
+      "display_name": "Ferenc Puskás",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "949984af-dcee-4f36-9f71-183d353d6b22"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-monumental",
+      "display_name": "Estadio Monumental",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "ef3af47e-9752-4cb6-aaa1-ba283affca02"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "vfl-bochum",
+      "display_name": "VfL Bochum",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0245064c-e0f7-40d8-9a92-fc52cb1b0dcd"
+      ]
+    },
+    {
+      "type": "manager",
+      "slug": "vincent-kompany",
+      "display_name": "Vincent Kompany",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0245064c-e0f7-40d8-9a92-fc52cb1b0dcd"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "asamoah-gyan",
+      "display_name": "Asamoah Gyan",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "038ab371-456a-4412-b517-9ebb798877af"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "fcsb",
+      "display_name": "FCSB",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e0615a3d-4996-4592-b80a-f3f76db3a88a"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "dinamo-bucuresti",
+      "display_name": "Dinamo București",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e0615a3d-4996-4592-b80a-f3f76db3a88a"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "stadionul-dinamo",
+      "display_name": "Stadionul Dinamo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "e0615a3d-4996-4592-b80a-f3f76db3a88a"
+      ]
+    },
+    {
+      "type": "player",
+      "slug": "leonardo-bonucci",
+      "display_name": "Leonardo Bonucci",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "05d81d8f-ad2a-4e35-97c3-04bdc0074809"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "palermo",
+      "display_name": "Palermo",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "05d81d8f-ad2a-4e35-97c3-04bdc0074809"
+      ]
+    },
+    {
+      "type": "trophy",
+      "slug": "efl-cup",
+      "display_name": "EFL Cup",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "33fd3005-3077-46d6-9c98-e715b4ae14b8"
+      ]
+    },
+    {
+      "type": "team",
+      "slug": "sc-beira-mar",
+      "display_name": "S.C. Beira-Mar",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0f9193b1-5bdf-4e19-be2d-95e36bc96f29"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-mario-duarte",
+      "display_name": "Estádio Mário Duarte",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0f9193b1-5bdf-4e19-be2d-95e36bc96f29"
+      ]
+    },
+    {
+      "type": "stadium",
+      "slug": "estadio-municipal-de-aveiro",
+      "display_name": "Estádio Municipal de Aveiro",
+      "aliases": [],
+      "mention_count": 1,
+      "sample_question_ids": [
+        "0f9193b1-5bdf-4e19-be2d-95e36bc96f29"
+      ]
+    }
+  ]
+}

--- a/backend/src/questions/classifiers/canonical-entities.ts
+++ b/backend/src/questions/classifiers/canonical-entities.ts
@@ -37,26 +37,36 @@ export interface CanonicalIndex {
   byType: Map<EntityType, CanonicalEntity[]>;
 }
 
-const CLEANED_PATH = path.resolve(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'scripts',
-  '_backfill-pool',
-  'canonical-entities.cleaned.json'
-);
+/**
+ * Resolved at runtime. The primary location is co-located with this module
+ * (bundled into dist via nest-cli assets). The scripts location is a fallback
+ * used only by CLI tools that run before the module is in dist.
+ */
+const CANDIDATE_PATHS = [
+  path.resolve(__dirname, 'canonical-entities.cleaned.json'),
+  path.resolve(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'scripts',
+    '_backfill-pool',
+    'canonical-entities.cleaned.json',
+  ),
+];
 
 let cache: CanonicalIndex | null = null;
 
-export function loadCanonicalEntities(filePath = CLEANED_PATH): CanonicalIndex {
+export function loadCanonicalEntities(filePath?: string): CanonicalIndex {
   if (cache) return cache;
-  if (!fs.existsSync(filePath)) {
+  const pathsToTry = filePath ? [filePath] : CANDIDATE_PATHS;
+  const found = pathsToTry.find((p) => fs.existsSync(p));
+  if (!found) {
     throw new Error(
-      `Canonical entities file not found at ${filePath}. Run pool:extract-entities + pool:review-entities first.`
+      `Canonical entities file not found. Tried: ${pathsToTry.join(', ')}. Run pool:extract-entities + pool:review-entities first.`,
     );
   }
-  const raw = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
+  const raw = JSON.parse(fs.readFileSync(found, 'utf8')) as {
     entities: CanonicalEntity[];
   };
   const all = raw.entities;

--- a/backend/src/questions/classifiers/canonical-entities.ts
+++ b/backend/src/questions/classifiers/canonical-entities.ts
@@ -1,0 +1,108 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Canonical entity loader.
+ *
+ * The cleaned entity list is the source of truth for valid subject_ids /
+ * league_ids. It's produced by the review UI
+ * (backend/scripts/review-canonical-entities.ts) and lives at
+ * backend/scripts/_backfill-pool/canonical-entities.cleaned.json.
+ *
+ * During backfill, the full list is embedded in the classifier's system prompt
+ * so Gemini can only pick a slug that exists here. Post-call validation rejects
+ * anything that drifted.
+ */
+
+export type EntityType =
+  | 'player'
+  | 'team'
+  | 'league'
+  | 'trophy'
+  | 'manager'
+  | 'stadium'
+  | 'country';
+
+export interface CanonicalEntity {
+  type: EntityType;
+  slug: string;
+  display_name: string;
+  aliases: string[];
+  mention_count: number;
+}
+
+export interface CanonicalIndex {
+  all: CanonicalEntity[];
+  bySlug: Map<string, CanonicalEntity>; // key: `${type}::${slug}`
+  byType: Map<EntityType, CanonicalEntity[]>;
+}
+
+const CLEANED_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'scripts',
+  '_backfill-pool',
+  'canonical-entities.cleaned.json'
+);
+
+let cache: CanonicalIndex | null = null;
+
+export function loadCanonicalEntities(filePath = CLEANED_PATH): CanonicalIndex {
+  if (cache) return cache;
+  if (!fs.existsSync(filePath)) {
+    throw new Error(
+      `Canonical entities file not found at ${filePath}. Run pool:extract-entities + pool:review-entities first.`
+    );
+  }
+  const raw = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
+    entities: CanonicalEntity[];
+  };
+  const all = raw.entities;
+  const bySlug = new Map<string, CanonicalEntity>();
+  const byType = new Map<EntityType, CanonicalEntity[]>();
+  for (const e of all) {
+    bySlug.set(`${e.type}::${e.slug}`, e);
+    if (!byType.has(e.type)) byType.set(e.type, []);
+    byType.get(e.type)!.push(e);
+  }
+  cache = { all, bySlug, byType };
+  return cache;
+}
+
+export function isKnownSlug(
+  index: CanonicalIndex,
+  type: EntityType,
+  slug: string
+): boolean {
+  return index.bySlug.has(`${type}::${slug}`);
+}
+
+/**
+ * Format the canonical list for embedding in a system prompt.
+ * Compact one-line-per-entity format, grouped by type.
+ * Example line: `lionel-messi | Lionel Messi | Leo Messi, La Pulga`
+ */
+export function formatCanonicalListForPrompt(index: CanonicalIndex): string {
+  const parts: string[] = [];
+  const orderedTypes: EntityType[] = [
+    'player',
+    'team',
+    'league',
+    'trophy',
+    'manager',
+    'stadium',
+    'country',
+  ];
+  for (const type of orderedTypes) {
+    const list = index.byType.get(type) ?? [];
+    if (list.length === 0) continue;
+    parts.push(`\n### ${type.toUpperCase()} (${list.length})`);
+    for (const e of list) {
+      const aliases = e.aliases.length ? ` | ${e.aliases.join(', ')}` : '';
+      parts.push(`${e.slug} | ${e.display_name}${aliases}`);
+    }
+  }
+  return parts.join('\n');
+}

--- a/backend/src/questions/classifiers/canonical-entities.ts
+++ b/backend/src/questions/classifiers/canonical-entities.ts
@@ -90,6 +90,21 @@ export function isKnownSlug(
 }
 
 /**
+ * Strip structural tokens from strings before they are embedded into a system
+ * prompt. Prevents adversarial display_names / aliases from introducing fake
+ * section headers or control sequences that could mislead the classifier.
+ * The canonical review pass should catch these, but defence-in-depth is cheap.
+ */
+function sanitiseForPrompt(s: string, max = 120): string {
+  return s
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/^#+\s*/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max);
+}
+
+/**
  * Format the canonical list for embedding in a system prompt.
  * Compact one-line-per-entity format, grouped by type.
  * Example line: `lionel-messi | Lionel Messi | Leo Messi, La Pulga`
@@ -110,8 +125,11 @@ export function formatCanonicalListForPrompt(index: CanonicalIndex): string {
     if (list.length === 0) continue;
     parts.push(`\n### ${type.toUpperCase()} (${list.length})`);
     for (const e of list) {
-      const aliases = e.aliases.length ? ` | ${e.aliases.join(', ')}` : '';
-      parts.push(`${e.slug} | ${e.display_name}${aliases}`);
+      const name = sanitiseForPrompt(e.display_name);
+      const aliases = e.aliases.length
+        ? ` | ${e.aliases.map((a) => sanitiseForPrompt(a)).join(', ')}`
+        : '';
+      parts.push(`${e.slug} | ${name}${aliases}`);
     }
   }
   return parts.join('\n');

--- a/backend/src/questions/classifiers/question-classifier.service.ts
+++ b/backend/src/questions/classifiers/question-classifier.service.ts
@@ -1,0 +1,301 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { LlmService } from '../../llm/llm.service';
+import {
+  CanonicalIndex,
+  EntityType,
+  formatCanonicalListForPrompt,
+  isKnownSlug,
+} from './canonical-entities';
+
+/**
+ * Classifies an existing pool question into structured taxonomy fields that
+ * match the new question_pool columns (subject_type/id, competition_id,
+ * question_style, mode_compatibility, concept_id, popularity_score, etc.).
+ *
+ * The canonical entity list is embedded in the system prompt so Gemini can
+ * only pick slugs that already exist. Anything that drifts is rejected
+ * post-call and the question is flagged for review.
+ */
+
+export type QuestionStyle =
+  | 'trivia'
+  | 'year'
+  | 'top5'
+  | 'multiple-choice'
+  | 'true-false'
+  | 'higher-or-lower'
+  | 'guess-score'
+  | 'player-id';
+
+export type GameMode =
+  | 'solo'
+  | 'duel'
+  | 'blitz'
+  | 'battle_royale'
+  | 'mayhem'
+  | 'hardcore'
+  | 'logo_quiz';
+
+export interface ClassifierInput {
+  id: string;
+  category: string;
+  difficulty?: string;
+  question_text: string;
+  correct_answer: string;
+  explanation?: string;
+}
+
+export interface ClassifierOutput {
+  subject_type: EntityType | null;
+  subject_id: string | null;
+  subject_name: string | null;
+  competition_id: string | null;
+  question_style: QuestionStyle | null;
+  answer_type: string | null;
+  mode_compatibility: GameMode[];
+  concept_id: string | null;
+  popularity_score: number | null;
+  time_sensitive: boolean;
+  valid_until: string | null;
+  tags: string[];
+}
+
+export interface ClassifierResult {
+  question_id: string;
+  classification: ClassifierOutput;
+  warnings: string[];
+  raw_subject_slug?: string;
+  raw_competition_slug?: string;
+}
+
+const ALLOWED_STYLES: readonly QuestionStyle[] = [
+  'trivia',
+  'year',
+  'top5',
+  'multiple-choice',
+  'true-false',
+  'higher-or-lower',
+  'guess-score',
+  'player-id',
+];
+
+const ALLOWED_MODES: readonly GameMode[] = [
+  'solo',
+  'duel',
+  'blitz',
+  'battle_royale',
+  'mayhem',
+  'hardcore',
+  'logo_quiz',
+];
+
+const ALLOWED_TYPES: readonly EntityType[] = [
+  'player',
+  'team',
+  'league',
+  'trophy',
+  'manager',
+  'stadium',
+  'country',
+];
+
+@Injectable()
+export class QuestionClassifierService {
+  private readonly logger = new Logger(QuestionClassifierService.name);
+
+  constructor(private readonly llm: LlmService) {}
+
+  async classify(
+    input: ClassifierInput,
+    canonical: CanonicalIndex
+  ): Promise<ClassifierResult> {
+    const systemPrompt = this.buildSystemPrompt(canonical);
+    const userPrompt = this.buildUserPrompt(input);
+
+    type Raw = {
+      subject_type: string | null;
+      subject_id: string | null;
+      subject_name: string | null;
+      competition_id: string | null;
+      question_style: string | null;
+      answer_type: string | null;
+      mode_compatibility: string[] | null;
+      concept_id: string | null;
+      popularity_score: number | null;
+      time_sensitive: boolean | null;
+      valid_until: string | null;
+      tags: string[] | null;
+    };
+
+    const raw = await this.llm.generateStructuredJson<Raw>(
+      systemPrompt,
+      userPrompt,
+      3
+    );
+
+    return this.validate(input.id, raw, canonical);
+  }
+
+  private buildSystemPrompt(canonical: CanonicalIndex): string {
+    const listBlock = formatCanonicalListForPrompt(canonical);
+    return `You classify an existing football (soccer) trivia question into structured taxonomy fields for a question pool. You DO NOT verify facts or rewrite content. You only infer categorical tags from what the question says.
+
+Return JSON with exactly these keys:
+  subject_type:        one of ["player","team","league","trophy","manager","stadium","country"] — the PRIMARY real-world entity the question is about, or null if none.
+  subject_id:          canonical slug of that primary entity. MUST come from the CANONICAL LIST below, matching the chosen subject_type. If no good match, return null.
+  subject_name:        display name of the subject (copy from the list), or null.
+  competition_id:      canonical slug of the specific competition scoping the question — either a LEAGUE slug (e.g. "premier-league", "serie-a") OR a TROPHY slug (e.g. "uefa-champions-league", "fifa-world-cup", "europa-league", "copa-del-rey"). null if the question is not scoped to a specific competition.
+  question_style:      one of ["trivia","year","top5","multiple-choice","true-false","higher-or-lower","guess-score","player-id"] — the SHAPE of the question, not its content. Infer from phrasing: "How many", "In what year", "Name the top 5", "Higher or lower than X", "Guess the score", "Identify this player".
+  answer_type:         short label for the answer's data type: "string", "year", "number", "team_name", "player_name", "country", "score", "boolean", "list".
+  mode_compatibility:  OPTIONAL array of modes this question is safe for, subset of ["solo","duel","blitz","battle_royale","mayhem","hardcore","logo_quiz"]. Return [] if you're not confident — this field is optional and empty is fine. Only populate modes you're sure the question works in. Exclude "blitz" for long-text questions. Exclude "logo_quiz" for anything that isn't a logo-identification question.
+  concept_id:          short kebab-case slug describing the UNDERLYING concept being tested, e.g. "world-cup-winners", "ballon-dor-history", "premier-league-top-scorers", "uefa-treble-teams", "club-stadium-matchups", "manager-trophy-history". Aim for broad reusable concepts, not question-specific. null if no clean concept applies.
+  popularity_score:    integer 1..100 measuring the FAME of the subject (not the difficulty of the question). Messi/Ronaldo = 95-100. Premier League = 95. A 1990s Greek Super League player = 10-25. Return null only if subject_type is null.
+  time_sensitive:      true if the correct answer can change over time (current manager of a club, top scorer of an active season, current league leader). false for historical facts.
+  valid_until:         ISO date "YYYY-MM-DD" if time_sensitive and you can estimate expiry. null otherwise.
+  tags:                array of other canonical slugs from the list that are MENTIONED in the question (secondary references). Up to 6. Empty array if none.
+
+STRICT RULES:
+- subject_id, competition_id, and every tag MUST appear verbatim in the CANONICAL LIST below. If the entity you'd pick is not in the list, return null for that field (not a made-up slug). This is critical — slug drift breaks the pool.
+- For COUNTRY slugs (both in subject_id when type="country" and in tags), always use the ISO alpha-2 code as listed ("no" for Norway, "gr" for Greece, "cz" for Czech Republic, "at" for Austria). NEVER use the country name as a slug. The list shows "no | Norway" — you output "no".
+- competition_id accepts a league slug OR a trophy slug (both types are valid — whichever specific competition the question is scoped to).
+- Do not invent slugs of any kind.
+- Do not hallucinate entities that are not named in the question.
+- Prefer a single strong primary subject over a weaker one. If the question asks "which club did X play for", the subject is the PLAYER (that's the anchor), and the answer/team goes into tags.
+- For a "top 5" or "name N" style question, subject_type is the TROPHY / LEAGUE the ranking is about. All listed teams/players go into tags.
+
+CANONICAL LIST (pick subject_id, competition_id, and tags ONLY from here):
+${listBlock}`;
+  }
+
+  private buildUserPrompt(q: ClassifierInput): string {
+    return `Classify this question:
+
+ID: ${q.id}
+Category: ${q.category}${q.difficulty ? `\nDifficulty: ${q.difficulty}` : ''}
+Question: ${q.question_text}
+Correct answer: ${q.correct_answer}${q.explanation ? `\nExplanation: ${q.explanation}` : ''}
+
+Return JSON with the exact keys defined in the system prompt. No extra keys.`;
+  }
+
+  private validate(
+    id: string,
+    raw: {
+      subject_type: string | null;
+      subject_id: string | null;
+      subject_name: string | null;
+      competition_id: string | null;
+      question_style: string | null;
+      answer_type: string | null;
+      mode_compatibility: string[] | null;
+      concept_id: string | null;
+      popularity_score: number | null;
+      time_sensitive: boolean | null;
+      valid_until: string | null;
+      tags: string[] | null;
+    },
+    canonical: CanonicalIndex
+  ): ClassifierResult {
+    const warnings: string[] = [];
+    const rawSubjectSlug = raw.subject_id ?? undefined;
+    const rawCompetitionSlug = raw.competition_id ?? undefined;
+
+    // subject_type
+    let subjectType: EntityType | null = null;
+    if (raw.subject_type && ALLOWED_TYPES.includes(raw.subject_type as EntityType)) {
+      subjectType = raw.subject_type as EntityType;
+    } else if (raw.subject_type) {
+      warnings.push(`invalid subject_type "${raw.subject_type}" — nulled`);
+    }
+
+    // subject_id — must be canonical
+    let subjectId: string | null = null;
+    if (subjectType && raw.subject_id) {
+      if (isKnownSlug(canonical, subjectType, raw.subject_id)) {
+        subjectId = raw.subject_id;
+      } else {
+        warnings.push(
+          `unknown subject_id "${raw.subject_id}" for type "${subjectType}" — nulled`
+        );
+      }
+    }
+    // If subject_id missing but type present, still null it (consistency).
+    if (subjectType && !subjectId) subjectType = subjectType; // keep type for context even if id null
+
+    // competition_id — must be canonical league OR trophy
+    let competitionId: string | null = null;
+    if (raw.competition_id) {
+      if (
+        isKnownSlug(canonical, 'league', raw.competition_id) ||
+        isKnownSlug(canonical, 'trophy', raw.competition_id)
+      ) {
+        competitionId = raw.competition_id;
+      } else {
+        warnings.push(`unknown competition_id "${raw.competition_id}" — nulled`);
+      }
+    }
+
+    // question_style
+    const style =
+      raw.question_style && ALLOWED_STYLES.includes(raw.question_style as QuestionStyle)
+        ? (raw.question_style as QuestionStyle)
+        : null;
+    if (raw.question_style && !style) {
+      warnings.push(`invalid question_style "${raw.question_style}" — nulled`);
+    }
+
+    // mode_compatibility
+    const modes: GameMode[] = [];
+    for (const m of raw.mode_compatibility ?? []) {
+      if (ALLOWED_MODES.includes(m as GameMode)) modes.push(m as GameMode);
+      else warnings.push(`dropped invalid mode "${m}"`);
+    }
+
+    // popularity_score
+    let popularity: number | null = null;
+    if (typeof raw.popularity_score === 'number') {
+      const v = Math.round(raw.popularity_score);
+      if (v >= 1 && v <= 100) popularity = v;
+      else warnings.push(`popularity_score out of range (${raw.popularity_score}) — nulled`);
+    }
+
+    // valid_until
+    let validUntil: string | null = null;
+    if (raw.valid_until) {
+      if (/^\d{4}-\d{2}-\d{2}$/.test(raw.valid_until)) validUntil = raw.valid_until;
+      else warnings.push(`invalid valid_until "${raw.valid_until}" — nulled`);
+    }
+
+    // tags — keep only canonical slugs (any type)
+    const tags: string[] = [];
+    for (const t of raw.tags ?? []) {
+      if (typeof t !== 'string' || !t) continue;
+      const known = ALLOWED_TYPES.some((type) => isKnownSlug(canonical, type, t));
+      if (known) tags.push(t);
+      else warnings.push(`dropped unknown tag "${t}"`);
+    }
+
+    return {
+      question_id: id,
+      classification: {
+        subject_type: subjectId ? subjectType : null,
+        subject_id: subjectId,
+        subject_name: subjectId
+          ? canonical.bySlug.get(`${subjectType}::${subjectId}`)?.display_name ?? raw.subject_name
+          : null,
+        competition_id: competitionId,
+        question_style: style,
+        answer_type: raw.answer_type && typeof raw.answer_type === 'string' ? raw.answer_type : null,
+        mode_compatibility: modes,
+        concept_id: raw.concept_id && typeof raw.concept_id === 'string' ? raw.concept_id : null,
+        popularity_score: popularity,
+        time_sensitive: Boolean(raw.time_sensitive),
+        valid_until: validUntil,
+        tags,
+      },
+      warnings,
+      raw_subject_slug: rawSubjectSlug,
+      raw_competition_slug: rawCompetitionSlug,
+    };
+  }
+}

--- a/backend/src/questions/classifiers/question-classifier.service.ts
+++ b/backend/src/questions/classifiers/question-classifier.service.ts
@@ -61,6 +61,9 @@ export interface ClassifierOutput {
   // event_year is classifier-sourced; era is a generated column (event_year);
   // league_tier and competition_type are filled by a trigger from competition_metadata.
   event_year: number | null;
+  // ISO alpha-2 of the primary person's country of origin. Only populated when
+  // subject_type is player, manager, or country. Powers future geo-themed modes.
+  nationality: string | null;
 }
 
 export interface ClassifierResult {
@@ -117,6 +120,9 @@ const ALLOWED_ANSWER_TYPES: readonly string[] = [
 // concept_id must be kebab-case, no leading/trailing hyphen, <=80 chars.
 const CONCEPT_ID_PATTERN = /^[a-z][a-z0-9-]{0,78}[a-z0-9]$/;
 
+// ISO 3166-1 alpha-2 country code.
+const NATIONALITY_PATTERN = /^[a-z]{2}$/;
+
 
 @Injectable()
 export class QuestionClassifierService {
@@ -145,6 +151,7 @@ export class QuestionClassifierService {
       valid_until: string | null;
       tags: string[] | null;
       event_year: number | null;
+      nationality: string | null;
     };
 
     const raw = await this.llm.generateStructuredJson<Raw>(
@@ -170,6 +177,14 @@ export class QuestionClassifierService {
     return null;
   }
 
+  private validateNationality(raw: unknown, warnings: string[]): string | null {
+    if (typeof raw !== 'string' || !raw) return null;
+    const lower = raw.toLowerCase();
+    if (NATIONALITY_PATTERN.test(lower)) return lower;
+    warnings.push(`invalid nationality "${raw}" — nulled`);
+    return null;
+  }
+
   private buildSystemPrompt(canonical: CanonicalIndex): string {
     const listBlock = formatCanonicalListForPrompt(canonical);
     return `You classify an existing football (soccer) trivia question into structured taxonomy fields for a question pool. You DO NOT verify facts or rewrite content. You only infer categorical tags from what the question says.
@@ -188,6 +203,7 @@ Return JSON with exactly these keys:
   valid_until:         ISO date "YYYY-MM-DD" if time_sensitive and you can estimate expiry. null otherwise.
   tags:                array of other canonical slugs from the list that are MENTIONED in the question (secondary references). Up to 6. Empty array if none.
   event_year:          integer 1850..current year. The primary year the question references (year of the match, trophy win, transfer, record, etc.). Null if the question is not year-anchored. (league_tier, competition_type, and era are NOT your responsibility — league_tier + competition_type are filled from a metadata table based on competition_id, and era is derived from event_year.)
+  nationality:         ISO 3166-1 alpha-2 lowercase code of the PRIMARY PERSON's country of origin — only populate when subject_type is "player" or "manager" (use the person's nationality, e.g. "ar" for Messi, "pt" for Ronaldo, "gr" for Mitroglou). When subject_type is "country", return that country's own ISO code. Return null for all other subject types (team, league, trophy, stadium) and when the subject's nationality is ambiguous or not clearly determinable from the question.
 
 STRICT RULES:
 - subject_id, competition_id, and every tag MUST appear verbatim in the CANONICAL LIST below. If the entity you'd pick is not in the list, return null for that field (not a made-up slug). This is critical — slug drift breaks the pool.
@@ -229,6 +245,7 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
       valid_until: string | null;
       tags: string[] | null;
       event_year: number | null;
+      nationality: string | null;
     },
     canonical: CanonicalIndex
   ): ClassifierResult {
@@ -336,6 +353,7 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
         valid_until: validUntil,
         tags,
         event_year: eventYear,
+        nationality: this.validateNationality(raw.nationality, warnings),
       },
       warnings,
       raw_subject_slug: rawSubjectSlug,

--- a/backend/src/questions/classifiers/question-classifier.service.ts
+++ b/backend/src/questions/classifiers/question-classifier.service.ts
@@ -58,6 +58,12 @@ export interface ClassifierOutput {
   time_sensitive: boolean;
   valid_until: string | null;
   tags: string[];
+  // Legacy analytics fields (shared with generator output). Populated here so
+  // classifier-only backfills keep analytics widgets accurate.
+  league_tier: number | null;
+  competition_type: string | null;
+  era: string | null;
+  event_year: number | null;
 }
 
 export interface ClassifierResult {
@@ -99,6 +105,17 @@ const ALLOWED_TYPES: readonly EntityType[] = [
   'country',
 ];
 
+const ALLOWED_ERAS = ['pre_1990', '1990s', '2000s', '2010s', '2020s'] as const;
+const ALLOWED_COMPETITION_TYPES = [
+  'domestic_league',
+  'domestic_cup',
+  'continental_club',
+  'international_national',
+  'youth',
+  'friendly',
+  'other',
+] as const;
+
 @Injectable()
 export class QuestionClassifierService {
   private readonly logger = new Logger(QuestionClassifierService.name);
@@ -125,6 +142,10 @@ export class QuestionClassifierService {
       time_sensitive: boolean | null;
       valid_until: string | null;
       tags: string[] | null;
+      league_tier: number | null;
+      competition_type: string | null;
+      era: string | null;
+      event_year: number | null;
     };
 
     const raw = await this.llm.generateStructuredJson<Raw>(
@@ -153,6 +174,10 @@ Return JSON with exactly these keys:
   time_sensitive:      true if the correct answer can change over time (current manager of a club, top scorer of an active season, current league leader). false for historical facts.
   valid_until:         ISO date "YYYY-MM-DD" if time_sensitive and you can estimate expiry. null otherwise.
   tags:                array of other canonical slugs from the list that are MENTIONED in the question (secondary references). Up to 6. Empty array if none.
+  league_tier:         integer 1..5 describing the prestige tier of the primary competition the question is about. 1 = top-5 EU leagues (Premier League / La Liga / Serie A / Bundesliga / Ligue 1) or top-tier continental competition (UEFA Champions League). 2 = other European top flights (Eredivisie, Primeira Liga, Süper Lig, Russian Premier League, etc.) or secondary continental (UEFA Europa League). 3 = other professional leagues (MLS, Saudi Pro League, J1 League, etc.) or tertiary continental. 4 = lower national divisions. 5 = amateur / youth / misc / national friendlies. Return null if the question is not competition-scoped (pure biographical, general history, etc.).
+  competition_type:    one of ["domestic_league","domestic_cup","continental_club","international_national","youth","friendly","other"]. Pick the one that best describes the competition the question is scoped to. Null if unclear or irrelevant.
+  era:                 one of ["pre_1990","1990s","2000s","2010s","2020s"] — which time period the question is about. Derive from event_year when you can. Null if truly timeless.
+  event_year:          integer 1850..current year. The primary year the question references (year of the match, trophy win, transfer, record, etc.). Null if the question is not year-anchored.
 
 STRICT RULES:
 - subject_id, competition_id, and every tag MUST appear verbatim in the CANONICAL LIST below. If the entity you'd pick is not in the list, return null for that field (not a made-up slug). This is critical — slug drift breaks the pool.
@@ -193,6 +218,10 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
       time_sensitive: boolean | null;
       valid_until: string | null;
       tags: string[] | null;
+      league_tier: number | null;
+      competition_type: string | null;
+      era: string | null;
+      event_year: number | null;
     },
     canonical: CanonicalIndex
   ): ClassifierResult {
@@ -266,6 +295,54 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
       else warnings.push(`invalid valid_until "${raw.valid_until}" — nulled`);
     }
 
+    // league_tier — 1..5
+    let leagueTier: number | null = null;
+    if (typeof raw.league_tier === 'number') {
+      const v = Math.round(raw.league_tier);
+      if (v >= 1 && v <= 5) leagueTier = v;
+      else warnings.push(`league_tier out of range (${raw.league_tier}) — nulled`);
+    }
+
+    // competition_type — enum
+    let competitionType: string | null = null;
+    if (raw.competition_type) {
+      if ((ALLOWED_COMPETITION_TYPES as readonly string[]).includes(raw.competition_type)) {
+        competitionType = raw.competition_type;
+      } else {
+        warnings.push(`invalid competition_type "${raw.competition_type}" — nulled`);
+      }
+    }
+
+    // era — enum (derived from event_year if missing)
+    let era: string | null = null;
+    if (raw.era) {
+      if ((ALLOWED_ERAS as readonly string[]).includes(raw.era)) {
+        era = raw.era;
+      } else {
+        warnings.push(`invalid era "${raw.era}" — nulled`);
+      }
+    }
+
+    // event_year — plausible range
+    let eventYear: number | null = null;
+    if (typeof raw.event_year === 'number') {
+      const v = Math.round(raw.event_year);
+      const now = new Date().getUTCFullYear();
+      if (v >= 1850 && v <= now + 1) {
+        eventYear = v;
+        // Derive era from year if era wasn't supplied or was rejected.
+        if (!era) {
+          if (v < 1990) era = 'pre_1990';
+          else if (v < 2000) era = '1990s';
+          else if (v < 2010) era = '2000s';
+          else if (v < 2020) era = '2010s';
+          else era = '2020s';
+        }
+      } else {
+        warnings.push(`event_year out of range (${raw.event_year}) — nulled`);
+      }
+    }
+
     // tags — keep only canonical slugs (any type)
     const tags: string[] = [];
     for (const t of raw.tags ?? []) {
@@ -292,6 +369,10 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
         time_sensitive: Boolean(raw.time_sensitive),
         valid_until: validUntil,
         tags,
+        league_tier: leagueTier,
+        competition_type: competitionType,
+        era,
+        event_year: eventYear,
       },
       warnings,
       raw_subject_slug: rawSubjectSlug,

--- a/backend/src/questions/classifiers/question-classifier.service.ts
+++ b/backend/src/questions/classifiers/question-classifier.service.ts
@@ -58,11 +58,8 @@ export interface ClassifierOutput {
   time_sensitive: boolean;
   valid_until: string | null;
   tags: string[];
-  // Legacy analytics fields (shared with generator output). Populated here so
-  // classifier-only backfills keep analytics widgets accurate.
-  league_tier: number | null;
-  competition_type: string | null;
-  era: string | null;
+  // event_year is classifier-sourced; era is a generated column (event_year);
+  // league_tier and competition_type are filled by a trigger from competition_metadata.
   event_year: number | null;
 }
 
@@ -105,16 +102,6 @@ const ALLOWED_TYPES: readonly EntityType[] = [
   'country',
 ];
 
-const ALLOWED_ERAS = ['pre_1990', '1990s', '2000s', '2010s', '2020s'] as const;
-const ALLOWED_COMPETITION_TYPES = [
-  'domestic_league',
-  'domestic_cup',
-  'continental_club',
-  'international_national',
-  'youth',
-  'friendly',
-  'other',
-] as const;
 
 @Injectable()
 export class QuestionClassifierService {
@@ -142,9 +129,6 @@ export class QuestionClassifierService {
       time_sensitive: boolean | null;
       valid_until: string | null;
       tags: string[] | null;
-      league_tier: number | null;
-      competition_type: string | null;
-      era: string | null;
       event_year: number | null;
     };
 
@@ -174,10 +158,7 @@ Return JSON with exactly these keys:
   time_sensitive:      true if the correct answer can change over time (current manager of a club, top scorer of an active season, current league leader). false for historical facts.
   valid_until:         ISO date "YYYY-MM-DD" if time_sensitive and you can estimate expiry. null otherwise.
   tags:                array of other canonical slugs from the list that are MENTIONED in the question (secondary references). Up to 6. Empty array if none.
-  league_tier:         integer 1..5 describing the prestige tier of the primary competition the question is about. 1 = top-5 EU leagues (Premier League / La Liga / Serie A / Bundesliga / Ligue 1) or top-tier continental competition (UEFA Champions League). 2 = other European top flights (Eredivisie, Primeira Liga, Süper Lig, Russian Premier League, etc.) or secondary continental (UEFA Europa League). 3 = other professional leagues (MLS, Saudi Pro League, J1 League, etc.) or tertiary continental. 4 = lower national divisions. 5 = amateur / youth / misc / national friendlies. Return null if the question is not competition-scoped (pure biographical, general history, etc.).
-  competition_type:    one of ["domestic_league","domestic_cup","continental_club","international_national","youth","friendly","other"]. Pick the one that best describes the competition the question is scoped to. Null if unclear or irrelevant.
-  era:                 one of ["pre_1990","1990s","2000s","2010s","2020s"] — which time period the question is about. Derive from event_year when you can. Null if truly timeless.
-  event_year:          integer 1850..current year. The primary year the question references (year of the match, trophy win, transfer, record, etc.). Null if the question is not year-anchored.
+  event_year:          integer 1850..current year. The primary year the question references (year of the match, trophy win, transfer, record, etc.). Null if the question is not year-anchored. (league_tier, competition_type, and era are NOT your responsibility — league_tier + competition_type are filled from a metadata table based on competition_id, and era is derived from event_year.)
 
 STRICT RULES:
 - subject_id, competition_id, and every tag MUST appear verbatim in the CANONICAL LIST below. If the entity you'd pick is not in the list, return null for that field (not a made-up slug). This is critical — slug drift breaks the pool.
@@ -218,9 +199,6 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
       time_sensitive: boolean | null;
       valid_until: string | null;
       tags: string[] | null;
-      league_tier: number | null;
-      competition_type: string | null;
-      era: string | null;
       event_year: number | null;
     },
     canonical: CanonicalIndex
@@ -295,52 +273,14 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
       else warnings.push(`invalid valid_until "${raw.valid_until}" — nulled`);
     }
 
-    // league_tier — 1..5
-    let leagueTier: number | null = null;
-    if (typeof raw.league_tier === 'number') {
-      const v = Math.round(raw.league_tier);
-      if (v >= 1 && v <= 5) leagueTier = v;
-      else warnings.push(`league_tier out of range (${raw.league_tier}) — nulled`);
-    }
-
-    // competition_type — enum
-    let competitionType: string | null = null;
-    if (raw.competition_type) {
-      if ((ALLOWED_COMPETITION_TYPES as readonly string[]).includes(raw.competition_type)) {
-        competitionType = raw.competition_type;
-      } else {
-        warnings.push(`invalid competition_type "${raw.competition_type}" — nulled`);
-      }
-    }
-
-    // era — enum (derived from event_year if missing)
-    let era: string | null = null;
-    if (raw.era) {
-      if ((ALLOWED_ERAS as readonly string[]).includes(raw.era)) {
-        era = raw.era;
-      } else {
-        warnings.push(`invalid era "${raw.era}" — nulled`);
-      }
-    }
-
-    // event_year — plausible range
+    // event_year — plausible range. era is derived DB-side (generated column);
+    // league_tier + competition_type are filled by the sync trigger.
     let eventYear: number | null = null;
     if (typeof raw.event_year === 'number') {
       const v = Math.round(raw.event_year);
       const now = new Date().getUTCFullYear();
-      if (v >= 1850 && v <= now + 1) {
-        eventYear = v;
-        // Derive era from year if era wasn't supplied or was rejected.
-        if (!era) {
-          if (v < 1990) era = 'pre_1990';
-          else if (v < 2000) era = '1990s';
-          else if (v < 2010) era = '2000s';
-          else if (v < 2020) era = '2010s';
-          else era = '2020s';
-        }
-      } else {
-        warnings.push(`event_year out of range (${raw.event_year}) — nulled`);
-      }
+      if (v >= 1850 && v <= now + 1) eventYear = v;
+      else warnings.push(`event_year out of range (${raw.event_year}) — nulled`);
     }
 
     // tags — keep only canonical slugs (any type)
@@ -369,9 +309,6 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
         time_sensitive: Boolean(raw.time_sensitive),
         valid_until: validUntil,
         tags,
-        league_tier: leagueTier,
-        competition_type: competitionType,
-        era,
         event_year: eventYear,
       },
       warnings,

--- a/backend/src/questions/classifiers/question-classifier.service.ts
+++ b/backend/src/questions/classifiers/question-classifier.service.ts
@@ -102,6 +102,21 @@ const ALLOWED_TYPES: readonly EntityType[] = [
   'country',
 ];
 
+const ALLOWED_ANSWER_TYPES: readonly string[] = [
+  'string',
+  'year',
+  'number',
+  'team_name',
+  'player_name',
+  'country',
+  'score',
+  'boolean',
+  'list',
+];
+
+// concept_id must be kebab-case, no leading/trailing hyphen, <=80 chars.
+const CONCEPT_ID_PATTERN = /^[a-z][a-z0-9-]{0,78}[a-z0-9]$/;
+
 
 @Injectable()
 export class QuestionClassifierService {
@@ -139,6 +154,20 @@ export class QuestionClassifierService {
     );
 
     return this.validate(input.id, raw, canonical);
+  }
+
+  private validateAnswerType(raw: unknown, warnings: string[]): string | null {
+    if (typeof raw !== 'string' || !raw) return null;
+    if (ALLOWED_ANSWER_TYPES.includes(raw)) return raw;
+    warnings.push(`invalid answer_type "${raw}" — nulled`);
+    return null;
+  }
+
+  private validateConceptId(raw: unknown, warnings: string[]): string | null {
+    if (typeof raw !== 'string' || !raw) return null;
+    if (CONCEPT_ID_PATTERN.test(raw)) return raw;
+    warnings.push(`invalid concept_id "${raw}" — nulled`);
+    return null;
   }
 
   private buildSystemPrompt(canonical: CanonicalIndex): string {
@@ -226,9 +255,6 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
         );
       }
     }
-    // If subject_id missing but type present, still null it (consistency).
-    if (subjectType && !subjectId) subjectType = subjectType; // keep type for context even if id null
-
     // competition_id — must be canonical league OR trophy
     let competitionId: string | null = null;
     if (raw.competition_id) {
@@ -298,13 +324,13 @@ Return JSON with the exact keys defined in the system prompt. No extra keys.`;
         subject_type: subjectId ? subjectType : null,
         subject_id: subjectId,
         subject_name: subjectId
-          ? canonical.bySlug.get(`${subjectType}::${subjectId}`)?.display_name ?? raw.subject_name
+          ? canonical.bySlug.get(`${subjectType}::${subjectId}`)?.display_name ?? null
           : null,
         competition_id: competitionId,
         question_style: style,
-        answer_type: raw.answer_type && typeof raw.answer_type === 'string' ? raw.answer_type : null,
+        answer_type: this.validateAnswerType(raw.answer_type, warnings),
         mode_compatibility: modes,
-        concept_id: raw.concept_id && typeof raw.concept_id === 'string' ? raw.concept_id : null,
+        concept_id: this.validateConceptId(raw.concept_id, warnings),
         popularity_score: popularity,
         time_sensitive: Boolean(raw.time_sensitive),
         valid_until: validUntil,

--- a/backend/src/questions/pool-seed.service.ts
+++ b/backend/src/questions/pool-seed.service.ts
@@ -710,10 +710,13 @@ export class PoolSeedService {
         },
         raw_score: q.raw_score ?? null,
         embedding: (q as GeneratedQuestion & { _embedding?: number[] })._embedding ?? null,
-        league_tier: q.analytics_tags?.league_tier ?? null,
-        competition_type: q.analytics_tags?.competition_type ?? null,
-        era: q.analytics_tags?.era ?? null,
-        event_year: q.analytics_tags?.event_year ?? null,
+        // Prefer generator-provided analytics_tags; fall back to classifier so
+        // analytics widgets stay accurate even for category generators that
+        // don't emit these fields.
+        league_tier: q.analytics_tags?.league_tier ?? tax?.league_tier ?? null,
+        competition_type: q.analytics_tags?.competition_type ?? tax?.competition_type ?? null,
+        era: q.analytics_tags?.era ?? tax?.era ?? null,
+        event_year: q.analytics_tags?.event_year ?? tax?.event_year ?? null,
         nationality: q.analytics_tags?.nationality ?? null,
         // Taxonomy fields from the classifier (nullable; classifier may skip).
         subject_type: tax?.subject_type ?? null,

--- a/backend/src/questions/pool-seed.service.ts
+++ b/backend/src/questions/pool-seed.service.ts
@@ -710,12 +710,14 @@ export class PoolSeedService {
         },
         raw_score: q.raw_score ?? null,
         embedding: (q as GeneratedQuestion & { _embedding?: number[] })._embedding ?? null,
-        // Prefer generator-provided analytics_tags; fall back to classifier so
-        // analytics widgets stay accurate even for category generators that
-        // don't emit these fields.
-        league_tier: q.analytics_tags?.league_tier ?? tax?.league_tier ?? null,
-        competition_type: q.analytics_tags?.competition_type ?? tax?.competition_type ?? null,
-        era: q.analytics_tags?.era ?? tax?.era ?? null,
+        // league_tier and competition_type are auto-populated by the
+        // sync_question_pool_competition_meta trigger based on competition_id.
+        // era is a generated column (derived from event_year), no longer writable.
+        // We still honour generator-provided overrides for league_tier /
+        // competition_type if analytics_tags supplies them (COALESCE in the
+        // trigger prefers non-NULL NEW values).
+        league_tier: q.analytics_tags?.league_tier ?? null,
+        competition_type: q.analytics_tags?.competition_type ?? null,
         event_year: q.analytics_tags?.event_year ?? tax?.event_year ?? null,
         nationality: q.analytics_tags?.nationality ?? null,
         // Taxonomy fields from the classifier (nullable; classifier may skip).

--- a/backend/src/questions/pool-seed.service.ts
+++ b/backend/src/questions/pool-seed.service.ts
@@ -716,7 +716,7 @@ export class PoolSeedService {
         league_tier: q.analytics_tags?.league_tier ?? null,
         competition_type: q.analytics_tags?.competition_type ?? null,
         event_year: q.analytics_tags?.event_year ?? tax?.event_year ?? null,
-        nationality: q.analytics_tags?.nationality ?? null,
+        nationality: q.analytics_tags?.nationality ?? tax?.nationality ?? null,
         // Taxonomy fields from the classifier (nullable; classifier may skip).
         subject_type: tax?.subject_type ?? null,
         subject_id: tax?.subject_id ?? null,

--- a/backend/src/questions/pool-seed.service.ts
+++ b/backend/src/questions/pool-seed.service.ts
@@ -63,16 +63,13 @@ export class PoolSeedService {
   ) {}
 
   /**
-   * Lazily-loaded canonical entity index for the classifier.
-   * First call reads the reviewed cleaned JSON; the in-memory result is reused
-   * across all subsequent seeding batches in this process.
+   * Resolve the canonical entity index. `loadCanonicalEntities` maintains its
+   * own module-level cache — we just wrap the read with a graceful fallback
+   * so a missing / unreadable JSON file never blocks pool seeding.
    */
-  private canonicalIndexCache: CanonicalIndex | null = null;
   private getCanonicalIndex(): CanonicalIndex | null {
-    if (this.canonicalIndexCache) return this.canonicalIndexCache;
     try {
-      this.canonicalIndexCache = loadCanonicalEntities();
-      return this.canonicalIndexCache;
+      return loadCanonicalEntities();
     } catch (err) {
       this.logger.warn(
         `[classifier] canonical entities not loadable — new questions will be inserted without taxonomy. ${(err as Error).message}`,

--- a/backend/src/questions/pool-seed.service.ts
+++ b/backend/src/questions/pool-seed.service.ts
@@ -6,6 +6,14 @@ import { LlmService } from '../llm/llm.service';
 import { QuestionsService } from './questions.service';
 import { QuestionValidator } from './validators/question.validator';
 import { QuestionIntegrityService } from './validators/question-integrity.service';
+import {
+  QuestionClassifierService,
+  ClassifierOutput,
+} from './classifiers/question-classifier.service';
+import {
+  CanonicalIndex,
+  loadCanonicalEntities,
+} from './classifiers/canonical-entities';
 import { RedisService } from '../redis/redis.service';
 import {
   BoardCategory,
@@ -49,9 +57,72 @@ export class PoolSeedService {
     private questionsService: QuestionsService,
     private questionValidator: QuestionValidator,
     private questionIntegrity: QuestionIntegrityService,
+    private questionClassifier: QuestionClassifierService,
     private redisService: RedisService,
     private readonly configService: ConfigService,
   ) {}
+
+  /**
+   * Lazily-loaded canonical entity index for the classifier.
+   * First call reads the reviewed cleaned JSON; the in-memory result is reused
+   * across all subsequent seeding batches in this process.
+   */
+  private canonicalIndexCache: CanonicalIndex | null = null;
+  private getCanonicalIndex(): CanonicalIndex | null {
+    if (this.canonicalIndexCache) return this.canonicalIndexCache;
+    try {
+      this.canonicalIndexCache = loadCanonicalEntities();
+      return this.canonicalIndexCache;
+    } catch (err) {
+      this.logger.warn(
+        `[classifier] canonical entities not loadable — new questions will be inserted without taxonomy. ${(err as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Classify a batch of generated questions against the canonical list.
+   * Runs sequentially to avoid Gemini 429s (same constraint as integrity
+   * verification). Returns a map keyed by question id; questions that fail to
+   * classify are absent from the map and their row inserts with null taxonomy.
+   */
+  private async classifyBatch(
+    questions: GeneratedQuestion[],
+    category: QuestionCategory,
+    difficulty: Difficulty,
+  ): Promise<Map<string, ClassifierOutput>> {
+    const canonical = this.getCanonicalIndex();
+    const out = new Map<string, ClassifierOutput>();
+    if (!canonical) return out;
+
+    for (const q of questions) {
+      try {
+        const res = await this.questionClassifier.classify(
+          {
+            id: q.id,
+            category,
+            difficulty,
+            question_text: q.question_text,
+            correct_answer: q.correct_answer,
+            explanation: q.explanation,
+          },
+          canonical,
+        );
+        out.set(q.id, res.classification);
+        if (res.warnings.length > 0) {
+          this.logger.debug(
+            `[classifier] ${q.id}: ${res.warnings.join(' | ')}`,
+          );
+        }
+      } catch (err) {
+        this.logger.warn(
+          `[classifier] failed for ${q.id}: ${(err as Error).message} — inserting with null taxonomy`,
+        );
+      }
+    }
+    return out;
+  }
 
   /**
    * Seeds a single slot (e.g. GUESS_SCORE/MEDIUM) with generated questions.
@@ -606,6 +677,14 @@ export class PoolSeedService {
   ): Promise<void> {
     if (questions.length === 0) return;
 
+    // Classify against canonical entity list. Failures degrade to null taxonomy
+    // so a classifier outage never blocks pool seeding.
+    const taxonomyByQuestion = await this.classifyBatch(
+      questions,
+      category,
+      difficultyOverride ?? questions[0].difficulty,
+    );
+
     const rows = questions.map((q) => {
       const difficulty = difficultyOverride ?? q.difficulty;
       let allowedDifficulties = q.allowedDifficulties ?? [difficulty];
@@ -613,6 +692,7 @@ export class PoolSeedService {
       if (difficultyOverride && !allowedDifficulties.includes(difficultyOverride)) {
         allowedDifficulties = [...allowedDifficulties, difficultyOverride];
       }
+      const tax = taxonomyByQuestion.get(q.id);
       return {
         id: q.id,
         category,
@@ -635,6 +715,21 @@ export class PoolSeedService {
         era: q.analytics_tags?.era ?? null,
         event_year: q.analytics_tags?.event_year ?? null,
         nationality: q.analytics_tags?.nationality ?? null,
+        // Taxonomy fields from the classifier (nullable; classifier may skip).
+        subject_type: tax?.subject_type ?? null,
+        subject_id: tax?.subject_id ?? null,
+        subject_name: tax?.subject_name ?? null,
+        competition_id: tax?.competition_id ?? null,
+        question_style: tax?.question_style ?? null,
+        answer_type: tax?.answer_type ?? null,
+        mode_compatibility: tax?.mode_compatibility && tax.mode_compatibility.length > 0
+          ? tax.mode_compatibility
+          : null,
+        concept_id: tax?.concept_id ?? null,
+        popularity_score: tax?.popularity_score ?? null,
+        time_sensitive: tax?.time_sensitive ?? false,
+        valid_until: tax?.valid_until ?? null,
+        tags: tax?.tags && tax.tags.length > 0 ? tax.tags : null,
       };
     });
 

--- a/backend/src/questions/questions.module.ts
+++ b/backend/src/questions/questions.module.ts
@@ -9,6 +9,7 @@ import { PoolIntegrityVerifierService } from './pool-integrity-verifier.service'
 import { AnswerValidator } from './validators/answer.validator';
 import { QuestionValidator } from './validators/question.validator';
 import { QuestionIntegrityService } from './validators/question-integrity.service';
+import { QuestionClassifierService } from './classifiers/question-classifier.service';
 import { AnswerTypeModifierService } from './answer-type-modifier.service';
 import { DifficultyScorer } from './difficulty-scorer.service';
 import { ThresholdConfigService } from './threshold-config.service';
@@ -36,6 +37,7 @@ import { LlmModule } from '../llm/llm.module';
     AnswerValidator,
     QuestionValidator,
     QuestionIntegrityService,
+    QuestionClassifierService,
     DifficultyScorer,
     HistoryGenerator,
     PlayerIdGenerator,
@@ -56,6 +58,7 @@ import { LlmModule } from '../llm/llm.module';
     AnswerValidator,
     QuestionValidator,
     QuestionIntegrityService,
+    QuestionClassifierService,
     ThresholdConfigService,
     MigratePoolDifficultyService,
     DifficultyScorer,

--- a/supabase/migrations/20260612000000_question_pool_taxonomy.sql
+++ b/supabase/migrations/20260612000000_question_pool_taxonomy.sql
@@ -1,0 +1,60 @@
+-- Structured taxonomy columns on question_pool for future mode/concept/personalization features.
+-- All columns nullable; existing rows backfilled separately by scripts/backfill-pool-taxonomy.ts.
+-- New questions populate these at generation time (SoloQuestionGenerator + category generators updated).
+
+ALTER TABLE question_pool
+  -- Entity identification
+  ADD COLUMN IF NOT EXISTS subject_type        TEXT
+    CHECK (subject_type IS NULL OR subject_type IN
+      ('player','team','league','trophy','match','manager','stadium','rule','transfer')),
+  ADD COLUMN IF NOT EXISTS subject_id          TEXT,
+  ADD COLUMN IF NOT EXISTS subject_name        TEXT,
+  ADD COLUMN IF NOT EXISTS league_id           TEXT,
+
+  -- Question character
+  ADD COLUMN IF NOT EXISTS question_style      TEXT
+    CHECK (question_style IS NULL OR question_style IN
+      ('trivia','year','top5','multiple-choice','true-false','higher-or-lower','guess-score','player-id')),
+  ADD COLUMN IF NOT EXISTS answer_type         TEXT,
+  ADD COLUMN IF NOT EXISTS mode_compatibility  TEXT[],
+  ADD COLUMN IF NOT EXISTS concept_id          TEXT,
+
+  -- Scoring / telemetry (solve_rate + avg_time_ms backfilled nightly from answer logs)
+  ADD COLUMN IF NOT EXISTS popularity_score    SMALLINT
+    CHECK (popularity_score IS NULL OR popularity_score BETWEEN 1 AND 100),
+  ADD COLUMN IF NOT EXISTS solve_rate          REAL
+    CHECK (solve_rate IS NULL OR (solve_rate >= 0 AND solve_rate <= 1)),
+  ADD COLUMN IF NOT EXISTS avg_time_ms         INTEGER
+    CHECK (avg_time_ms IS NULL OR avg_time_ms >= 0),
+
+  -- Content lifecycle
+  ADD COLUMN IF NOT EXISTS time_sensitive      BOOLEAN DEFAULT false NOT NULL,
+  ADD COLUMN IF NOT EXISTS valid_until         DATE,
+  ADD COLUMN IF NOT EXISTS tags                TEXT[];
+
+COMMENT ON COLUMN question_pool.subject_type       IS 'Primary entity type this question is about. Enum; extend via ALTER CHECK when new types arise.';
+COMMENT ON COLUMN question_pool.subject_id         IS 'Canonical slug of primary entity, e.g. "lionel-messi", "arsenal-fc". Validated against canonical-entities.json at generation time.';
+COMMENT ON COLUMN question_pool.subject_name       IS 'Display name of subject for admin UI.';
+COMMENT ON COLUMN question_pool.league_id          IS 'Specific league slug, e.g. "premier-league". Nullable when question is not league-scoped. Distinct from league_tier (abstraction level).';
+COMMENT ON COLUMN question_pool.question_style     IS 'Shape of the question, not its content. Drives input UI + mode gating.';
+COMMENT ON COLUMN question_pool.answer_type        IS 'Answer data type (matches AnswerType enum in common/interfaces/question.interface.ts).';
+COMMENT ON COLUMN question_pool.mode_compatibility IS 'Game modes this question is safe to draw for: solo, duel, blitz, battle_royale, mayhem, hardcore, logo_quiz. NULL = unclassified.';
+COMMENT ON COLUMN question_pool.concept_id         IS 'Underlying concept being tested, e.g. "world-cup-winners". Enables mastery tracking + spaced repetition across questions.';
+COMMENT ON COLUMN question_pool.popularity_score   IS 'Fame of the subject (1-100). Decoupled from difficulty_score — obscure topics can have easy questions and vice versa.';
+COMMENT ON COLUMN question_pool.solve_rate         IS 'Aggregate percent correct, computed nightly from answer logs. NULL until enough telemetry.';
+COMMENT ON COLUMN question_pool.avg_time_ms        IS 'Average time-to-answer in ms, computed nightly. NULL until enough telemetry.';
+COMMENT ON COLUMN question_pool.time_sensitive     IS 'True if the correct answer can change over time (e.g. "current Arsenal manager"). Use with valid_until.';
+COMMENT ON COLUMN question_pool.valid_until        IS 'Expiry date after which time_sensitive questions must be re-verified.';
+COMMENT ON COLUMN question_pool.tags               IS 'Loose secondary references (other entities, themes). Use subject_id for primary filter; use tags for discovery-style filters.';
+
+-- Indexes sized for expected filter patterns.
+-- subject_type is almost always queried with subject_id — composite covers both.
+CREATE INDEX IF NOT EXISTS idx_question_pool_subject           ON question_pool(subject_type, subject_id);
+CREATE INDEX IF NOT EXISTS idx_question_pool_league_id         ON question_pool(league_id);
+CREATE INDEX IF NOT EXISTS idx_question_pool_concept_id        ON question_pool(concept_id);
+CREATE INDEX IF NOT EXISTS idx_question_pool_popularity        ON question_pool(popularity_score);
+CREATE INDEX IF NOT EXISTS idx_question_pool_mode_compat       ON question_pool USING GIN (mode_compatibility);
+CREATE INDEX IF NOT EXISTS idx_question_pool_tags              ON question_pool USING GIN (tags);
+
+-- Expiry index is partial: only rows that actually have valid_until set, which is a small subset.
+CREATE INDEX IF NOT EXISTS idx_question_pool_valid_until       ON question_pool(valid_until) WHERE valid_until IS NOT NULL;

--- a/supabase/migrations/20260612010000_rename_league_to_competition.sql
+++ b/supabase/migrations/20260612010000_rename_league_to_competition.sql
@@ -1,0 +1,13 @@
+-- league_id was too narrow — questions can be scoped to tournaments/trophies
+-- (UEFA Champions League, FIFA World Cup, Copa del Rey) that aren't "leagues".
+-- Rename to competition_id; it now accepts league OR trophy canonical slugs.
+-- competition_type (separate column from 20260609100000) keeps the abstraction level.
+
+ALTER TABLE question_pool RENAME COLUMN league_id TO competition_id;
+ALTER INDEX idx_question_pool_league_id RENAME TO idx_question_pool_competition_id;
+
+COMMENT ON COLUMN question_pool.competition_id IS
+  'Canonical slug of the specific competition scoping this question. '
+  'May reference a league slug (e.g. "premier-league", "serie-a") OR a '
+  'trophy/tournament slug (e.g. "uefa-champions-league", "fifa-world-cup"). '
+  'Use competition_type for the abstraction level.';

--- a/supabase/migrations/20260612020000_subject_type_add_country.sql
+++ b/supabase/migrations/20260612020000_subject_type_add_country.sql
@@ -1,0 +1,9 @@
+-- subject_type CHECK was missing 'country' — classifier returns it for
+-- questions like "In which country is stadium X located?" but the DB rejected
+-- the insert. Add it. The pre-existing 'match'/'rule'/'transfer' values remain
+-- for future use.
+
+ALTER TABLE question_pool DROP CONSTRAINT question_pool_subject_type_check;
+ALTER TABLE question_pool ADD CONSTRAINT question_pool_subject_type_check
+  CHECK (subject_type IS NULL OR subject_type IN
+    ('player','team','league','trophy','match','manager','stadium','rule','transfer','country'));

--- a/supabase/migrations/20260612030000_competition_metadata.sql
+++ b/supabase/migrations/20260612030000_competition_metadata.sql
@@ -1,0 +1,66 @@
+-- competition_metadata: single source of truth for league / trophy / award facts.
+-- Referenced by question_pool.competition_id. A trigger auto-fills the legacy
+-- denormalised columns (league_tier, competition_type) on insert/update so the
+-- classifier no longer has to produce them — and we avoid drift.
+--
+-- entity_type is finer-grained than the canonical-entities "type":
+--   league  — any competitive league (domestic or continental league phase)
+--   trophy  — knockout cup / tournament trophy
+--   award   — individual honour (Ballon d'Or, Golden Boot). Not a competition
+--             per se, but useful for themed modes, so we keep them here for
+--             discoverability. Tier stays NULL for awards.
+
+CREATE TABLE IF NOT EXISTS competition_metadata (
+  id                TEXT PRIMARY KEY,
+  entity_type       TEXT NOT NULL CHECK (entity_type IN ('league','trophy','award')),
+  display_name      TEXT NOT NULL,
+  tier              SMALLINT CHECK (tier IS NULL OR tier BETWEEN 1 AND 5),
+  competition_type  TEXT CHECK (competition_type IS NULL OR competition_type IN
+    ('domestic_league','domestic_cup','continental_club','international_national','youth','friendly','other')),
+  country_code      TEXT CHECK (country_code IS NULL OR country_code ~ '^[a-z]{2}$'),
+  founded_year      SMALLINT CHECK (founded_year IS NULL OR (founded_year BETWEEN 1850 AND 2100)),
+  defunct_year      SMALLINT CHECK (defunct_year IS NULL OR (defunct_year BETWEEN 1850 AND 2100)),
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  competition_metadata     IS 'Canonical facts for every league / trophy / award referenced by question_pool.competition_id.';
+COMMENT ON COLUMN competition_metadata.tier             IS '1..5 prestige rank (1 = top-5 EU or UCL/FWC). NULL for awards and unclassified.';
+COMMENT ON COLUMN competition_metadata.competition_type IS 'Abstract category: domestic_league | domestic_cup | continental_club | international_national | youth | friendly | other.';
+COMMENT ON COLUMN competition_metadata.country_code     IS 'ISO alpha-2 host country for domestic competitions. NULL for continental/international.';
+COMMENT ON COLUMN competition_metadata.defunct_year     IS 'Year the competition ended / was rebranded. NULL for active competitions.';
+
+CREATE INDEX IF NOT EXISTS idx_competition_metadata_tier         ON competition_metadata(tier);
+CREATE INDEX IF NOT EXISTS idx_competition_metadata_type         ON competition_metadata(competition_type);
+CREATE INDEX IF NOT EXISTS idx_competition_metadata_country      ON competition_metadata(country_code);
+CREATE INDEX IF NOT EXISTS idx_competition_metadata_entity_type  ON competition_metadata(entity_type);
+
+-- Trigger: when a question row has a competition_id, copy tier + competition_type
+-- from competition_metadata into the denormalised columns. Skips if the
+-- metadata is missing or if the competition_id is an award (tier is NULL there).
+CREATE OR REPLACE FUNCTION sync_question_pool_competition_meta()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.competition_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT
+    COALESCE(NEW.league_tier, cm.tier),
+    COALESCE(NEW.competition_type, cm.competition_type)
+  INTO NEW.league_tier, NEW.competition_type
+  FROM competition_metadata cm
+  WHERE cm.id = NEW.competition_id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION sync_question_pool_competition_meta() IS
+  'Populates question_pool.league_tier + competition_type from competition_metadata when competition_id is set. Classifier-provided values win (COALESCE prefers NEW over lookup) so a model override is still possible.';
+
+DROP TRIGGER IF EXISTS trg_sync_competition_meta ON question_pool;
+CREATE TRIGGER trg_sync_competition_meta
+  BEFORE INSERT OR UPDATE OF competition_id ON question_pool
+  FOR EACH ROW
+  EXECUTE FUNCTION sync_question_pool_competition_meta();

--- a/supabase/migrations/20260612040000_era_generated_column.sql
+++ b/supabase/migrations/20260612040000_era_generated_column.sql
@@ -1,0 +1,28 @@
+-- era was redundant with event_year. Convert it into a STORED generated
+-- column derived from event_year so it self-maintains and nothing in
+-- analytics code has to change (era is still a real column you can SELECT,
+-- GROUP BY, and index — just no longer writable).
+--
+-- Postgres requires dropping the existing column first; since the trigger
+-- for competition metadata only writes league_tier and competition_type,
+-- dropping era is safe — no trigger touches it.
+
+ALTER TABLE question_pool DROP COLUMN IF EXISTS era;
+
+ALTER TABLE question_pool ADD COLUMN era TEXT
+  GENERATED ALWAYS AS (
+    CASE
+      WHEN event_year IS NULL            THEN NULL
+      WHEN event_year < 1990             THEN 'pre_1990'
+      WHEN event_year < 2000             THEN '1990s'
+      WHEN event_year < 2010             THEN '2000s'
+      WHEN event_year < 2020             THEN '2010s'
+      ELSE                                    '2020s'
+    END
+  ) STORED;
+
+COMMENT ON COLUMN question_pool.era IS
+  'Generated column: derived from event_year. pre_1990 | 1990s | 2000s | 2010s | 2020s | NULL. Cannot be written directly; update event_year.';
+
+-- The old era index was dropped with the column; recreate on the generated one.
+CREATE INDEX IF NOT EXISTS idx_question_pool_era ON question_pool(era);

--- a/supabase/migrations/20260612050000_trigger_warns_on_missing_competition.sql
+++ b/supabase/migrations/20260612050000_trigger_warns_on_missing_competition.sql
@@ -1,0 +1,36 @@
+-- Make drift visible: when a question is written with a competition_id that
+-- doesn't exist in competition_metadata, the trigger previously did nothing
+-- silently (PL/pgSQL leaves SELECT INTO targets unchanged when no row matches).
+-- That meant league_tier + competition_type stayed NULL forever with no signal.
+-- Now we RAISE WARNING so unknown competitions surface in Supabase logs and
+-- future extraction-review passes catch them.
+
+CREATE OR REPLACE FUNCTION sync_question_pool_competition_meta()
+RETURNS TRIGGER AS $$
+DECLARE
+  matched_tier SMALLINT;
+  matched_type TEXT;
+  found BOOLEAN := false;
+BEGIN
+  IF NEW.competition_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT cm.tier, cm.competition_type
+  INTO matched_tier, matched_type
+  FROM competition_metadata cm
+  WHERE cm.id = NEW.competition_id;
+
+  IF FOUND THEN
+    NEW.league_tier      := COALESCE(NEW.league_tier, matched_tier);
+    NEW.competition_type := COALESCE(NEW.competition_type, matched_type);
+  ELSE
+    RAISE WARNING 'sync_question_pool_competition_meta: competition_id "%" has no row in competition_metadata — league_tier / competition_type will remain whatever NEW supplied (likely NULL). Run pool:extract-competitions + seed to fix.', NEW.competition_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION sync_question_pool_competition_meta() IS
+  'Populates question_pool.league_tier + competition_type from competition_metadata when competition_id is set. Classifier-provided values win (COALESCE prefers NEW over lookup) so a model override is still possible. Emits RAISE WARNING for unknown competition_ids so silent drift is visible in logs.';


### PR DESCRIPTION
## Summary

Adds a structured taxonomy layer to `question_pool` so future modes (themed quizzes, concept mastery, geo-filtering, adaptive difficulty) can be built without more schema migrations. Every existing non-logo question is backfilled; every new question auto-classifies on generation.

**15 new columns** on `question_pool`, populated by a new `QuestionClassifierService` (Gemini + canonical entity allowlist). Legacy analytics columns (`league_tier`, `competition_type`, `era`) now dedupe through a `competition_metadata` lookup table with a sync trigger + generated column.

## What's in here

- **6 migrations** (applied to prod during development):
  - Taxonomy columns + indexes (`subject_*`, `competition_id`, `question_style`, `answer_type`, `mode_compatibility`, `concept_id`, `popularity_score`, `solve_rate`, `avg_time_ms`, `time_sensitive`, `valid_until`, `tags`)
  - Rename `league_id` → `competition_id` (accepts league or trophy slugs)
  - Add `country` to `subject_type` CHECK
  - New `competition_metadata` table + `sync_question_pool_competition_meta` trigger
  - `era` → `GENERATED ALWAYS AS STORED` (from `event_year`)
  - Trigger `RAISE WARNING` on unknown `competition_id`
- **Classifier service** at `backend/src/questions/classifiers/question-classifier.service.ts`. Strict validation: every slug must appear in `canonical-entities.cleaned.json` or gets nulled. Never allows Gemini to invent new slugs.
- **Canonical entity list** (1,122 reviewed entities) bundled into the runtime build via `nest-cli.json` assets config.
- **Pool-seed integration** — `persistQuestionsToPool` now calls the classifier before every INSERT. Failures degrade to null taxonomy, never block seeding.
- **Logo-quiz cache invalidation** in `seed-logo-questions.ts` so newly-seeded logos appear in the team select immediately instead of after a 1h TTL.
- **Three CLI scripts:**
  - `pool:extract-entities` — builds canonical list from existing pool
  - `pool:review-entities` — interactive HTML review UI (localStorage-backed)
  - `pool:extract-competitions` + `pool:seed-competitions` — competition metadata pipeline
  - `pool:backfill-taxonomy` — with `--pilot`, `--resume`, `--apply`, paginated

## Backfill results (2,128 non-logo questions)

| Field | Coverage | Notes |
|---|---|---|
| subject_type/id/name | 87.8% | Strict validation against canonical list |
| competition_id | 71.6% | Nullable when not comp-scoped |
| question_style | 100% | |
| concept_id | 99.7% | Used for future mastery tracking |
| popularity_score | 98.5% | Subject fame, decoupled from difficulty |
| event_year / era | 67.7% | era auto-derives via generated column |
| league_tier / competition_type | 72.9% / 74.6% | Trigger-filled from competition_metadata |
| nationality | 39.6% overall, 83% of applicable | ISO alpha-2 for player/manager/country subjects |
| time_sensitive | 7.8% flagged | Classifier identifies when facts can change |

## Review results

All 8 findings from internal code review resolved (6 auto-fix, 1 critical trigger fix, 1 informational deferred). Zero unresolved.

## Test plan

- [ ] Backend boots cleanly with canonical JSON bundled in `dist/`
- [ ] Generate a new question via `npm run pool:seed` — verify all 16 taxonomy fields populated
- [ ] Trigger fires: INSERT with unknown competition_id surfaces as RAISE WARNING in Supabase logs
- [ ] Trigger fires: INSERT with known competition_id auto-fills `league_tier` + `competition_type`
- [ ] `analytics.service.ts` still returns correct `by_era` / `by_competition_type` / `by_league_tier` buckets
- [ ] Logo-quiz `/api/logo-quiz/teams` still works (untouched behavior-wise)
- [ ] Seed logos — confirm cache invalidates (newly-seeded team appears in select within seconds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)