### PR TITLE
feat(ui): safe-area insets on all top-level routes + header bleeds into notch

### DIFF
--- a/frontend/src/app/features/admin/admin-legacy.css
+++ b/frontend/src/app/features/admin/admin-legacy.css
@@ -3,7 +3,11 @@
   background: #0f0f12;
   color: #e4e4e7;
   min-height: 100vh;
-  padding: 2rem;
+  padding:
+    calc(env(safe-area-inset-top, 0px) + 2rem)
+    calc(env(safe-area-inset-right, 0px) + 2rem)
+    calc(env(safe-area-inset-bottom, 0px) + 2rem)
+    calc(env(safe-area-inset-left, 0px) + 2rem);
 }
 
 .admin-header {

--- a/frontend/src/app/features/battle-royale/battle-royale-play.css
+++ b/frontend/src/app/features/battle-royale/battle-royale-play.css
@@ -2,7 +2,11 @@
   min-height: 100vh;
   background: var(--color-background);
   color: var(--color-foreground);
-  padding: 1rem;
+  padding:
+    calc(env(safe-area-inset-top, 0px) + 1rem)
+    calc(env(safe-area-inset-right, 0px) + 1rem)
+    calc(env(safe-area-inset-bottom, 0px) + 1rem)
+    calc(env(safe-area-inset-left, 0px) + 1rem);
   max-width: var(--content-max-width);
   margin: 0 auto;
 }

--- a/frontend/src/app/features/duel/duel-play.html
+++ b/frontend/src/app/features/duel/duel-play.html
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-background max-w-md mx-auto">
+<div class="min-h-screen bg-background max-w-md mx-auto pt-safe pb-safe pl-safe pr-safe">
 
   <!-- ── WAITING: no opponent yet ───────────────────────────────────────── -->
   @if (store.phase() === 'waiting') {

--- a/frontend/src/app/features/game/game.css
+++ b/frontend/src/app/features/game/game.css
@@ -54,6 +54,9 @@
 }
 
 .game-back-btn {
+  /* Push beneath the notch / Dynamic Island on iOS. */
+  top: calc(env(safe-area-inset-top, 0px) + 1rem) !important;
+  left: calc(env(safe-area-inset-left, 0px) + 1rem) !important;
   background: rgba(20, 20, 22, 0.45);
   backdrop-filter: blur(var(--glass-blur-sm)) saturate(1.4);
   -webkit-backdrop-filter: blur(var(--glass-blur-sm)) saturate(1.4);

--- a/frontend/src/app/features/game/game.html
+++ b/frontend/src/app/features/game/game.html
@@ -1,4 +1,4 @@
-<div class="game-shell relative min-h-screen max-w-md mx-auto flex flex-col">
+<div class="game-shell relative min-h-screen max-w-md mx-auto flex flex-col pt-safe pb-safe">
   @if (store.phase() !== 'loading' && store.phase() !== 'finished' && store.phase() !== 'question') {
     <button
       (click)="goBack()"

--- a/frontend/src/app/features/landing/landing.scss
+++ b/frontend/src/app/features/landing/landing.scss
@@ -1,5 +1,13 @@
 :host { display: block; background: #0a0a0a; color: #fff; }
-.landing { max-width: 1200px; margin: 0 auto; padding: 0 24px; }
+.landing {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding:
+    env(safe-area-inset-top, 0px)
+    calc(env(safe-area-inset-right, 0px) + 24px)
+    env(safe-area-inset-bottom, 0px)
+    calc(env(safe-area-inset-left, 0px) + 24px);
+}
 
 /* Typographic scale — hybrid: marketing-large on desktop, comfortable on mobile */
 .hero__headline { font-size: 44px; line-height: 1.05; font-weight: 800; margin: 16px 0 12px; }
@@ -49,7 +57,13 @@
 
 /* Desktop breakpoint — hybrid marketing-scale */
 @media (min-width: 768px) {
-  .landing { padding: 0 32px; }
+  .landing {
+    padding:
+      env(safe-area-inset-top, 0px)
+      calc(env(safe-area-inset-right, 0px) + 32px)
+      env(safe-area-inset-bottom, 0px)
+      calc(env(safe-area-inset-left, 0px) + 32px);
+  }
   .hero { grid-template-columns: 1.1fr 1fr; gap: 48px; padding: 96px 0; align-items: center; }
   .hero__headline { font-size: 72px; }
   .hero__subhead { font-size: 20px; }

--- a/frontend/src/app/features/match-detail/match-detail.css
+++ b/frontend/src/app/features/match-detail/match-detail.css
@@ -1,8 +1,12 @@
 /* ── Page layout ─────────────────────────── */
 .match-detail-page {
   min-height: 100dvh;
-  padding: 1rem;
-  padding-bottom: 2rem;
+  /* Top inset is handled by <app-lobby-header>; only pad sides + bottom for the notch / home indicator. */
+  padding:
+    1rem
+    calc(env(safe-area-inset-right, 0px) + 1rem)
+    calc(env(safe-area-inset-bottom, 0px) + 2rem)
+    calc(env(safe-area-inset-left, 0px) + 1rem);
   max-width: 32rem;
   margin: 0 auto;
   display: flex;

--- a/frontend/src/app/features/not-found/not-found.css
+++ b/frontend/src/app/features/not-found/not-found.css
@@ -4,7 +4,11 @@
   align-items: center;
   justify-content: center;
   background: var(--color-bg, #000);
-  padding: 2rem;
+  padding:
+    calc(env(safe-area-inset-top, 0px) + 2rem)
+    calc(env(safe-area-inset-right, 0px) + 2rem)
+    calc(env(safe-area-inset-bottom, 0px) + 2rem)
+    calc(env(safe-area-inset-left, 0px) + 2rem);
 }
 
 .not-found__content {

--- a/frontend/src/app/features/onboarding/onboarding.css
+++ b/frontend/src/app/features/onboarding/onboarding.css
@@ -8,7 +8,11 @@
   display: flex;
   flex-direction: column;
   background: var(--mat-sys-surface);
-  padding: 1rem;
+  padding:
+    calc(env(safe-area-inset-top, 0px) + 1rem)
+    calc(env(safe-area-inset-right, 0px) + 1rem)
+    calc(env(safe-area-inset-bottom, 0px) + 1rem)
+    calc(env(safe-area-inset-left, 0px) + 1rem);
 }
 .onboarding-inner {
   flex: 1;

--- a/frontend/src/app/features/online-game/join-invite.html
+++ b/frontend/src/app/features/online-game/join-invite.html
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-background flex items-center justify-center p-4">
+<div class="min-h-screen bg-background flex items-center justify-center p-4 pt-safe pb-safe pl-safe pr-safe">
   <div class="max-w-sm w-full text-center">
     <div class="text-5xl mb-4">⚽</div>
     <h1 class="text-2xl mb-2"><span class="brand-text" data-text="STEPOVR.">STEPOVR.</span> <span class="text-base font-sans font-bold not-italic tracking-normal">1v1</span></h1>

--- a/frontend/src/app/features/online-game/online-play.html
+++ b/frontend/src/app/features/online-game/online-play.html
@@ -1,4 +1,4 @@
-<div class="relative min-h-screen bg-background max-w-md mx-auto">
+<div class="relative min-h-screen bg-background max-w-md mx-auto pt-safe pb-safe pl-safe pr-safe">
   @switch (store.phase()) {
     <!-- ═══ WAITING: invite code + share ═══ -->
     @case ('waiting') {

--- a/frontend/src/app/shared/top-nav/top-nav.css
+++ b/frontend/src/app/shared/top-nav/top-nav.css
@@ -1,15 +1,20 @@
 .top-nav {
   position: fixed;
+  /* Bleed up to y:0 so the glass background covers the iOS notch /
+     Dynamic Island area instead of leaving a transparent strip. */
   top: 0;
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
   max-width: var(--app-max-width);
-  height: 3.75rem;
+  /* Visible chrome height stays 3.75rem; total grows by the inset. */
+  height: calc(3.75rem + env(safe-area-inset-top, 0px));
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 var(--space-4);
+  /* Inset padding pushes interactive children below the notch while the
+     background continues to fill the safe-area band above. */
+  padding: env(safe-area-inset-top, 0px) var(--space-4) 0;
   z-index: 50;
   background: var(--glass-bg-default);
   backdrop-filter: blur(var(--glass-blur-lg));

--- a/frontend/src/styles/base/_safe-area.css
+++ b/frontend/src/styles/base/_safe-area.css
@@ -1,0 +1,27 @@
+/* ==========================================================
+   Safe-area utilities — for screens rendered outside the
+   <app-shell> wrapper (which already pads for the notch /
+   home-indicator). Apply these on the root container of any
+   top-level route (onboarding, login, game, play screens, …)
+   so content never collides with the iPhone notch, Dynamic
+   Island, or home indicator.
+   ========================================================== */
+
+.pt-safe   { padding-top:    env(safe-area-inset-top, 0px); }
+.pb-safe   { padding-bottom: env(safe-area-inset-bottom, 0px); }
+.pl-safe   { padding-left:   env(safe-area-inset-left, 0px); }
+.pr-safe   { padding-right:  env(safe-area-inset-right, 0px); }
+
+.mt-safe   { margin-top:     env(safe-area-inset-top, 0px); }
+.mb-safe   { margin-bottom:  env(safe-area-inset-bottom, 0px); }
+
+.top-safe  { top:  env(safe-area-inset-top, 0px); }
+.left-safe { left: env(safe-area-inset-left, 0px); }
+
+/* Convenience: apply safe-area insets to all four sides. */
+.safe-area-screen {
+  padding-top:    env(safe-area-inset-top, 0px);
+  padding-right:  env(safe-area-inset-right, 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  padding-left:   env(safe-area-inset-left, 0px);
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -13,6 +13,7 @@
 @import './base/_animations.css';
 @import './base/_animation-utils.css';
 @import './base/_a11y.css';
+@import './base/_safe-area.css';
 
 /* Components — shared utility classes */
 @import './components/_glass.css';


### PR DESCRIPTION
## Problem
On iPhone (and any device with a top notch / dynamic island), several top-level screens — onboarding, not-found, match-detail, battle-royale-play, admin-legacy, landing, game, online-play, duel-play, join-invite — were rendering content under the status bar because they were not children of `<app-shell>` and therefore didn't pick up the existing `shell-main` safe-area inset.

The chrome top-nav also left an empty band above itself equal to `env(safe-area-inset-top)`.

## Changes
- New `frontend/src/styles/base/_safe-area.css` with `.pt-safe / .pb-safe / .pl-safe / .pr-safe` utility classes, wired in via `styles/index.css`.
- Per-screen CSS / HTML root containers now apply the safe-area inset on all four sides (or via the new utility classes for Tailwind-only screens).
- `top-nav.css`: `top: 0`, height grown by `env(safe-area-inset-top)`, internal padding pushes children below the notch — the glass header now bleeds visually all the way to the top edge.

## Test plan
- iPhone 15 simulator (notched), Safari + standalone PWA: verify no content under the status bar on every listed route, and the top-nav fully covers the safe-area band.
- Android & desktop: `env(safe-area-inset-*)` resolves to 0px → no visual regression.