### PR TITLE
fix(auth): private-relay handling, instant username refresh, real error messages

### DIFF
--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -72,8 +72,12 @@ export class App implements OnInit, OnDestroy {
 
   private async checkUsernameSetup(userId: string): Promise<void> {
     try {
-      const isSet = await this.auth.fetchUsernameSet(userId);
-      if (!isSet) {
+      const { usernameSet, username } = await this.auth.fetchProfileMeta(userId);
+      // Force the modal even if username_set is true when the stored username
+      // is still an Apple Hide-My-Email relay id (legacy rows from before
+      // migration 20260616000001) — it's effectively unusable as a display name.
+      const looksLikeRelayId = !!username && /^[a-f0-9]{16,}$/i.test(username);
+      if (!usernameSet || looksLikeRelayId) {
         this.usernameModal.open();
       } else {
         this.usernameModal.close();

--- a/frontend/src/app/core/auth.service.ts
+++ b/frontend/src/app/core/auth.service.ts
@@ -22,6 +22,13 @@ export class AuthService {
       auth: {
         // Use no-op lock to avoid NavigatorLockAcquireTimeoutError (multi-tab / strict mode contention)
         lock: async (_name, _acquireTimeout, fn) => fn(),
+        // Use PKCE for browser OAuth — avoids implicit-flow nonce mismatches
+        // ("Passed nonce and nonce in id_token should either both exist or not")
+        // when redirecting back from Google / Apple.
+        flowType: 'pkce',
+        detectSessionInUrl: true,
+        persistSession: true,
+        autoRefreshToken: true,
       },
     });
     // Restore session from localStorage — guard must await sessionReady before checking
@@ -59,11 +66,35 @@ export class AuthService {
     return (data as { username_set?: boolean } | null)?.username_set ?? false;
   }
 
+  /**
+   * Returns both `username_set` and the current `username` so callers can
+   * decide whether to (re)open the username modal — e.g. when the stored
+   * username is still an Apple Hide-My-Email relay id from a legacy signup.
+   */
+  async fetchProfileMeta(userId: string): Promise<{ usernameSet: boolean; username: string | null }> {
+    const { data } = await this.supabase
+      .from('profiles')
+      .select('username_set, username')
+      .eq('id', userId)
+      .single();
+    const row = data as { username_set?: boolean; username?: string | null } | null;
+    return {
+      usernameSet: row?.username_set ?? false,
+      username: row?.username ?? null,
+    };
+  }
+
   async signInWithGoogle(): Promise<void> {
     if (Capacitor.isNativePlatform()) {
       const { GoogleAuth } = await import('@southdevs/capacitor-google-auth');
       await GoogleAuth.initialize();
-      const googleUser = await GoogleAuth.signIn({ scopes: ['profile', 'email'] });
+      const googleUser = await GoogleAuth.signIn({
+        scopes: ['profile', 'email'],
+        serverClientId: '215249721443-drub176d1u1jha7pl9uvvuo596uspbo5.apps.googleusercontent.com',
+      });
+      // Note: requires "Skip nonce checks" enabled on the Google provider in
+      // Supabase — the native @southdevs/capacitor-google-auth SDK doesn't
+      // expose the nonce used when issuing the id_token.
       const { error } = await this.supabase.auth.signInWithIdToken({
         provider: 'google',
         token: googleUser.authentication.idToken,
@@ -144,5 +175,27 @@ export class AuthService {
   async resetPasswordForEmail(email: string): Promise<void> {
     const { error } = await this.supabase.auth.resetPasswordForEmail(email);
     if (error) throw error;
+  }
+
+  /**
+   * Patch the locally-cached Supabase user metadata (e.g. after the user picks
+   * a username for the first time) so any signal computed from `auth.user()`
+   * — like the top-nav `displayName` — updates immediately, without waiting
+   * for a page reload or the next auth event.
+   */
+  async refreshUserMetadata(patch: Record<string, unknown>): Promise<void> {
+    const { data, error } = await this.supabase.auth.updateUser({ data: patch });
+    if (error) throw error;
+    if (data.user) this._user.set(data.user);
+  }
+
+  /**
+   * Apple Sign in with Hide-My-Email returns an address of the form
+   *   {hex}@privaterelay.appleid.com
+   * which is fine for delivery but ugly to display in the UI. This helper
+   * lets the UI substitute a friendlier label.
+   */
+  static isPrivateRelayEmail(email: string | null | undefined): boolean {
+    return !!email && /@privaterelay\.appleid\.com$/i.test(email);
   }
 }

--- a/frontend/src/app/core/error.interceptor.ts
+++ b/frontend/src/app/core/error.interceptor.ts
@@ -30,7 +30,12 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
       } else if (err.status === 0) {
         toast.show('Connection lost. Check your network.', 'error');
       } else if (err.status >= 500) {
-        toast.show('Something went wrong. Please try again.', 'error');
+        const serverMsg =
+          (typeof err.error === 'string' ? err.error : null) ??
+          err.error?.message ??
+          err.error?.error ??
+          err.message;
+        toast.show(serverMsg ? `Server error: ${serverMsg}` : 'Something went wrong. Please try again.', 'error');
       }
       return throwError(() => err);
     }),

--- a/frontend/src/app/shared/auth-modal/auth-modal.ts
+++ b/frontend/src/app/shared/auth-modal/auth-modal.ts
@@ -52,7 +52,8 @@ export class AuthModalComponent {
         this.modalService.close();
       }
     } catch (err: any) {
-      this.error.set(err?.message ?? 'Authentication failed');
+      const msg = err?.error?.message ?? err?.error_description ?? err?.message;
+      this.error.set(msg ? `Sign-in failed: ${msg}` : 'Authentication failed. Please try again.');
     } finally {
       this.loading.set(false);
     }
@@ -67,7 +68,8 @@ export class AuthModalComponent {
       this.analytics.track('login', { method: 'google' });
       if (this.platform.isNative) this.modalService.close();
     } catch (err: any) {
-      this.error.set(err?.message ?? 'Google sign-in failed');
+      const msg = err?.error?.message ?? err?.error_description ?? err?.message;
+      this.error.set(msg ? `Google sign-in failed: ${msg}` : 'Google sign-in failed. Please try again.');
       this.loading.set(false);
       this.googleLoading.set(false);
     }
@@ -82,7 +84,14 @@ export class AuthModalComponent {
       this.analytics.track('login', { method: 'apple' });
       if (this.platform.isNative) this.modalService.close();
     } catch (err: any) {
-      this.error.set(err?.message ?? 'Apple sign-in failed');
+      // Capacitor / Apple cancellations shouldn't be surfaced as errors
+      const code = err?.code ?? err?.error;
+      if (code === 'ERR_CANCELED' || code === '1001' || /cancel/i.test(String(err?.message ?? ''))) {
+        this.error.set(null);
+      } else {
+        const msg = err?.error?.message ?? err?.error_description ?? err?.message;
+        this.error.set(msg ? `Apple sign-in failed: ${msg}` : 'Apple sign-in failed. Please try again.');
+      }
     } finally {
       this.loading.set(false);
       this.appleLoading.set(false);

--- a/frontend/src/app/shared/top-nav/top-nav.html
+++ b/frontend/src/app/shared/top-nav/top-nav.html
@@ -166,7 +166,7 @@
           </div>
           <div>
             <p class="tsp__profile-name">{{ displayName() }}</p>
-            <p class="tsp__profile-email">{{ auth.user()?.email }}</p>
+            <p class="tsp__profile-email">{{ visibleEmail() }}</p>
           </div>
         </div>
       }

--- a/frontend/src/app/shared/top-nav/top-nav.ts
+++ b/frontend/src/app/shared/top-nav/top-nav.ts
@@ -75,11 +75,28 @@ export class TopNavComponent implements OnInit {
     return typeof fromIdentity === 'string' ? fromIdentity : null;
   });
 
-  displayName = computed(() =>
-    this.auth.user()?.user_metadata?.['username'] ??
-    this.auth.user()?.user_metadata?.['full_name'] ??
-    this.auth.user()?.email ?? 'User'
-  );
+  displayName = computed(() => {
+    const user = this.auth.user();
+    if (!user) return 'User';
+    const meta = user.user_metadata ?? {};
+    const fromMeta = (meta['username'] as string | undefined) ?? (meta['full_name'] as string | undefined);
+    if (fromMeta) return fromMeta;
+    const profileUsername = this.store.profile()?.username;
+    if (profileUsername && !this.looksLikePrivateRelayId(profileUsername)) return profileUsername;
+    if (user.email && !AuthService.isPrivateRelayEmail(user.email)) return user.email;
+    return 'Player';
+  });
+
+  /** Email shown in the settings panel — hide ugly Apple Hide-My-Email relay addresses. */
+  visibleEmail = computed(() => {
+    const email = this.auth.user()?.email ?? '';
+    return AuthService.isPrivateRelayEmail(email) ? '' : email;
+  });
+
+  private looksLikePrivateRelayId(name: string): boolean {
+    // Hide-My-Email default usernames look like 32+ char hex strings
+    return /^[a-f0-9]{16,}$/i.test(name);
+  }
 
   initials = computed(() => {
     const name = String(this.displayName());

--- a/frontend/src/app/shared/username-modal/username-modal.ts
+++ b/frontend/src/app/shared/username-modal/username-modal.ts
@@ -2,6 +2,8 @@ import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/cor
 import { FormsModule } from '@angular/forms';
 import { UsernameModalService } from '../../core/username-modal.service';
 import { ProfileApiService } from '../../core/profile-api.service';
+import { ProfileStore } from '../../core/profile-store.service';
+import { AuthService } from '../../core/auth.service';
 import { AnalyticsService } from '../../core/analytics.service';
 
 @Component({
@@ -15,6 +17,8 @@ import { AnalyticsService } from '../../core/analytics.service';
 export class UsernameModalComponent {
   private modalService = inject(UsernameModalService);
   private profileApi = inject(ProfileApiService);
+  private profileStore = inject(ProfileStore);
+  private auth = inject(AuthService);
   private analytics = inject(AnalyticsService);
 
   username = '';
@@ -46,15 +50,27 @@ export class UsernameModalComponent {
     this.serverError.set(null);
     this.loading.set(true);
     try {
-      await this.profileApi.setUsername(this.username.trim());
+      const trimmed = this.username.trim();
+      await this.profileApi.setUsername(trimmed);
       this.analytics.track('username_set');
+
+      // Refresh both signals the header binds to so it updates without a page reload:
+      //  - ProfileStore.profile (read by top-nav `username`)
+      //  - auth.user().user_metadata.username (read by top-nav `displayName`)
+      await Promise.all([
+        this.profileStore.refresh().catch(() => undefined),
+        this.auth.refreshUserMetadata({ username: trimmed }).catch(() => undefined),
+      ]);
+
       this.modalService.close();
     } catch (err: any) {
       const status = err?.status ?? err?.error?.statusCode;
       if (status === 409) {
         this.serverError.set('Username already taken — try another');
       } else {
-        this.serverError.set(err?.error?.message ?? err?.message ?? 'Something went wrong');
+        const apiMsg = err?.error?.message ?? err?.error?.error;
+        const msg = apiMsg ?? err?.message;
+        this.serverError.set(msg ? `Couldn’t save username: ${msg}` : 'Couldn’t save username. Please try again.');
       }
     } finally {
       this.loading.set(false);

--- a/supabase/migrations/20260616000001_friendlier_default_username.sql
+++ b/supabase/migrations/20260616000001_friendlier_default_username.sql
@@ -1,0 +1,50 @@
+-- Friendlier default username for new signups.
+--
+-- Previous behaviour: `username = split_part(email, '@', 1)`.
+--   * For Apple "Hide My Email" users this produced an unreadable
+--     32-char hex string (the relay id) as the visible username.
+--   * For everyone else it leaked the local part of the email.
+--
+-- New behaviour:
+--   1. Use `raw_user_meta_data.username` if the client supplied one (email signup).
+--   2. Use `raw_user_meta_data.full_name` first token if present (Google).
+--   3. Otherwise fall back to `player_<first 8 of uuid>` — neutral, unique,
+--      and obviously a placeholder so the user is prompted to change it.
+--
+-- The `username_set` flag is left at its default (false), so the username
+-- modal will still open on first login regardless of which fallback was used.
+
+create or replace function handle_new_user()
+returns trigger as $$
+declare
+  meta_username text := nullif(new.raw_user_meta_data->>'username', '');
+  meta_fullname text := nullif(new.raw_user_meta_data->>'full_name', '');
+  email_local   text := nullif(split_part(coalesce(new.email, ''), '@', 1), '');
+  email_domain  text := lower(split_part(coalesce(new.email, ''), '@', 2));
+  candidate     text;
+begin
+  -- Prefer an explicit username from the signup payload.
+  candidate := meta_username;
+
+  -- Then a first-name from Google's full_name.
+  if candidate is null and meta_fullname is not null then
+    candidate := split_part(meta_fullname, ' ', 1);
+  end if;
+
+  -- Then the email local part — but NOT for Apple's private relay,
+  -- which gives a hex-string that's worse than no name at all.
+  if candidate is null
+     and email_local is not null
+     and email_domain <> 'privaterelay.appleid.com' then
+    candidate := email_local;
+  end if;
+
+  -- Final fallback: deterministic, unique-per-user placeholder.
+  if candidate is null then
+    candidate := 'player_' || substr(replace(new.id::text, '-', ''), 1, 8);
+  end if;
+
+  insert into public.profiles (id, username) values (new.id, candidate);
+  return new;
+end;
+$$ language plpgsql security definer;


### PR DESCRIPTION
## Problems reported
1. Apple "Hide My Email" caused `{id}@privaterelay.appleid.com` to show as the username/email throughout the app.
2. After picking a username in the onboarding modal, the header still showed the old id until a manual page refresh.
3. Native Google sign-in failed with `Passed nonce and nonce in id_token should either both exist or not`.
4. Most auth failures surfaced a generic "Something went wrong" with no useful detail.

## Fixes
- **Private-relay display** — `AuthService.isPrivateRelayEmail()` helper; `top-nav.displayName` skips relay addresses and hex-only profile usernames; settings-panel email is blanked via `visibleEmail()`.
- **Username modal** — `submit()` now refreshes `ProfileStore` AND patches Supabase user metadata (`auth.refreshUserMetadata({ username })`), so signals bound to either source update immediately.
- **Defensive re-open** — `app.ts checkUsernameSetup()` re-opens the modal when the stored username matches `^[a-f0-9]{16,}$` even if `username_set` is true (covers legacy rows from before the trigger migration).
- **Google nonce** — Supabase client uses explicit `flowType: 'pkce'` for web OAuth (no implicit-flow nonce check). The native id-token path requires the **Skip nonce checks** toggle on the Google provider in Supabase — see comment in `auth.service.ts`.
- **Error messages** — `auth-modal`, `username-modal`, and the HTTP error interceptor now surface `err.error.message` / `err.error_description` / `err.message` with a contextual prefix ("Apple sign-in failed: …", "Server error: …"). Apple user-cancellations are no longer surfaced as errors.

## DB migration
`supabase/migrations/20260616000001_friendlier_default_username.sql` replaces `handle_new_user()` so new signups get a sensible default:

`raw_user_meta_data.username` → first token of `full_name` → email local part (skipped for privaterelay) → `player_<8 hex of uuid>`.

> Already applied to the remote DB via the management API for this project; the migration file is committed for parity.

## Manual checks before merging
- [ ] In Supabase → Auth → Providers → Google, **Skip nonce checks** is ON.
- [ ] Native Apple sign-in with Hide-My-Email shows 'Player' (or username after modal), not the relay id.
- [ ] After picking a username in the modal, header updates without a page reload.