### PR TITLE
chore(scripts): add supabase-sql.sh helper for ad-hoc remote SQL

### DIFF
--- a/scripts/supabase-sql.sh
+++ b/scripts/supabase-sql.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run a SQL file or stdin against the linked Supabase project via the
+# Management API. Useful when local migrations have drifted from remote
+# (so `supabase db push` would fail) and you just want to apply one
+# idempotent change.
+#
+# Usage:
+#   scripts/supabase-sql.sh path/to/file.sql
+#   echo "select 1" | scripts/supabase-sql.sh
+#
+# Reads SUPABASE_ACCESS_TOKEN and SUPABASE_PROJECT_REF from .env (gitignored).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ -f .env ]]; then
+  set -a; . ./.env; set +a
+fi
+
+: "${SUPABASE_ACCESS_TOKEN:?SUPABASE_ACCESS_TOKEN missing — set it in .env}"
+: "${SUPABASE_PROJECT_REF:?SUPABASE_PROJECT_REF missing — set it in .env}"
+
+if [[ $# -ge 1 && -f "$1" ]]; then
+  SQL=$(cat "$1")
+else
+  SQL=$(cat)
+fi
+
+curl -fsS -X POST "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/database/query" \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data "$(jq -nc --arg q "$SQL" '{query:$q}')"
+echo


### PR DESCRIPTION
Small bash wrapper around the Supabase Management API (`POST /v1/projects/{ref}/database/query`) that reads `SUPABASE_ACCESS_TOKEN` + `SUPABASE_PROJECT_REF` from the gitignored `.env`.

Useful when local migration history has drifted from the remote project (so `supabase db push` would fail) and you just want to apply a single idempotent change — e.g. a `create or replace function` migration.

```bash
scripts/supabase-sql.sh path/to/file.sql
echo 'select 1' | scripts/supabase-sql.sh
```

No runtime impact.