### PR TITLE
fix(ui): safe-area follow-ups for home, shell, and force-update banner

### DIFF
--- a/frontend/src/app/features/home/home.css
+++ b/frontend/src/app/features/home/home.css
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 5.5rem 1rem 7.5rem;
+  padding: calc(5.5rem + env(safe-area-inset-top, 0px)) 1rem 7.5rem;
   position: relative;
   overflow: hidden;
 }

--- a/frontend/src/app/layout/shell/shell.css
+++ b/frontend/src/app/layout/shell/shell.css
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  padding-top: env(safe-area-inset-top, 0px);
   /* Reserve space so fixed bottom-nav never covers page content.
      ~64px pill + 8px top padding + 8px bottom padding + safe area. */
   padding-bottom: calc(5.5rem + env(safe-area-inset-bottom));

--- a/frontend/src/app/shared/force-update-banner/force-update-banner.css
+++ b/frontend/src/app/shared/force-update-banner/force-update-banner.css
@@ -70,6 +70,13 @@
 /* ── Soft update banner (reuses notification-banner pattern) ── */
 
 .banner {
+  position: fixed;
+  bottom: calc(6.5rem + env(safe-area-inset-bottom, 0px));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10000;
+  width: calc(100% - 2rem);
+  max-width: var(--app-max-width);
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -83,8 +90,8 @@
 }
 
 @keyframes banner-slide-in {
-  from { opacity: 0; transform: translateY(-6px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
 
 .banner--update {


### PR DESCRIPTION
Follow-ups to #103 — three places I missed in the original safe-area sweep.

- **`shell.css`** — `shell-main` now adds `padding-top: env(safe-area-inset-top)`. This matters specifically on the home route, which sets `--no-top-pad` to let the page scroll under the fixed top-nav; without this, content went under the dynamic island.
- **`home.css`** — bump `.home-page` top padding by `env(safe-area-inset-top)` so the hero block clears the notch.
- **`force-update-banner.css`** — turn the soft-update banner into a fixed bottom toast (above the bottom-nav + safe-area inset), centered, with `translateX(-50%)` baked into the keyframes so it doesn't snap left mid slide-in.

## Test
- iPhone 15 simulator (notched), home route: hero no longer hides under dynamic island.
- Trigger a soft update (force-update banner shows): banner sits above bottom-nav, centered, slide-in is smooth (no horizontal jump).