### PR TITLE
fix(crashlytics): record HTTP 5xx and network errors as non-fatals

### DIFF
--- a/frontend/src/app/core/crashlytics.service.ts
+++ b/frontend/src/app/core/crashlytics.service.ts
@@ -7,11 +7,27 @@ export class CrashlyticsService {
 
   constructor(private ngZone: NgZone) {}
 
-  async recordException(error: unknown): Promise<void> {
+  async recordException(error: unknown, context?: Record<string, string | number | boolean>): Promise<void> {
     if (!this.isNative) return;
     try {
       const { FirebaseCrashlytics } = await import('@capacitor-firebase/crashlytics');
-      const message = error instanceof Error ? error.message : String(error);
+      const baseMessage = error instanceof Error ? error.message : String(error);
+      const ctxSuffix = context
+        ? ' | ' +
+          Object.entries(context)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ')
+        : '';
+      const message = (baseMessage || 'Unknown error') + ctxSuffix;
+
+      if (context) {
+        await Promise.all(
+          Object.entries(context).map(([key, value]) =>
+            FirebaseCrashlytics.setCustomKey({ key, value: String(value), type: 'string' }).catch(() => {}),
+          ),
+        );
+      }
+
       await FirebaseCrashlytics.recordException({ message });
     } catch {
       // Plugin not available — no-op

--- a/frontend/src/app/core/error.interceptor.ts
+++ b/frontend/src/app/core/error.interceptor.ts
@@ -4,11 +4,13 @@ import { catchError, throwError, retry, timer } from 'rxjs';
 import { ToastService } from './toast.service';
 import { AuthModalService } from './auth-modal.service';
 import { ProService } from './pro.service';
+import { CrashlyticsService } from './crashlytics.service';
 
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const toast = inject(ToastService);
   const authModal = inject(AuthModalService);
   const pro = inject(ProService);
+  const crashlytics = inject(CrashlyticsService);
 
   return next(req).pipe(
     retry({
@@ -23,6 +25,12 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
       },
     }),
     catchError((err: HttpErrorResponse) => {
+      const serverMsg =
+        (typeof err.error === 'string' ? err.error : null) ??
+        err.error?.message ??
+        err.error?.error ??
+        err.message;
+
       if (err.status === 401) {
         authModal.open();
       } else if (err.status === 402) {
@@ -30,14 +38,25 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
       } else if (err.status === 0) {
         toast.show('Connection lost. Check your network.', 'error');
       } else if (err.status >= 500) {
-        const serverMsg =
-          (typeof err.error === 'string' ? err.error : null) ??
-          err.error?.message ??
-          err.error?.error ??
-          err.message;
         toast.show(serverMsg ? `Server error: ${serverMsg}` : 'Something went wrong. Please try again.', 'error');
       }
+
+      // Report network failures and 5xx to Crashlytics so they show up as non-fatals.
+      // Skip 4xx (other than 0/5xx) — those are usually expected app-level errors.
+      if (err.status === 0 || err.status >= 500) {
+        void crashlytics.recordException(new Error(`HTTP ${err.status} ${req.method} ${stripQuery(req.url)}: ${serverMsg ?? 'no message'}`), {
+          http_status: err.status,
+          http_method: req.method,
+          http_url: stripQuery(req.url),
+        });
+      }
+
       return throwError(() => err);
     }),
   );
 };
+
+function stripQuery(url: string): string {
+  const i = url.indexOf('?');
+  return i === -1 ? url : url.slice(0, i);
+}


### PR DESCRIPTION
## Why

Firebase Crashlytics dashboard only shows release **1.1(2)** even though the app is at **1.6(6)** and we've had real failures (e.g. two recent "Server error: …" toasts from 5xx responses). Reason: `errorInterceptor` was showing the toast and re-throwing, but most subscribers handle the error, so it never reached `GlobalErrorHandler` → `recordException` was never called. Crashlytics only lists versions that sent at least one event, so newer versions stay invisible until something actually crashes natively.

## What

- `errorInterceptor`: explicitly call `CrashlyticsService.recordException` for `status === 0` (network down) and `status >= 500`, with method, URL (query stripped), and status attached.
- `CrashlyticsService.recordException`: now accepts an optional `context` map and forwards each entry via `setCustomKey` so it shows on the issue detail page in addition to the message line.
- 4xx (other than 401/402 already routed) is intentionally **not** reported — those are usually expected app-level errors and would just be noise.

## Effect on the version question

Once a single 5xx / network error fires on a build, that build will start showing up under "Versions" in the Firebase console. No more silently invisible releases.