### PR TITLE
fix(auth): record sign-in errors to Crashlytics + surface error code

### DIFF
--- a/frontend/src/app/shared/auth-modal/auth-modal.ts
+++ b/frontend/src/app/shared/auth-modal/auth-modal.ts
@@ -5,6 +5,7 @@ import { AuthService } from '../../core/auth.service';
 import { AuthModalService } from '../../core/auth-modal.service';
 import { PlatformService } from '../../core/platform.service';
 import { AnalyticsService } from '../../core/analytics.service';
+import { CrashlyticsService } from '../../core/crashlytics.service';
 
 @Component({
   selector: 'app-auth-modal',
@@ -19,6 +20,7 @@ export class AuthModalComponent {
   platform = inject(PlatformService);
   private auth = inject(AuthService);
   private analytics = inject(AnalyticsService);
+  private crashlytics = inject(CrashlyticsService);
 
   mode = signal<'signin' | 'signup'>('signin');
   loading = signal(false);
@@ -52,8 +54,9 @@ export class AuthModalComponent {
         this.modalService.close();
       }
     } catch (err: any) {
-      const msg = err?.error?.message ?? err?.error_description ?? err?.message;
+      const msg = this.extractMessage(err);
       this.error.set(msg ? `Sign-in failed: ${msg}` : 'Authentication failed. Please try again.');
+      this.reportAuthError('email', err);
     } finally {
       this.loading.set(false);
     }
@@ -68,8 +71,10 @@ export class AuthModalComponent {
       this.analytics.track('login', { method: 'google' });
       if (this.platform.isNative) this.modalService.close();
     } catch (err: any) {
-      const msg = err?.error?.message ?? err?.error_description ?? err?.message;
-      this.error.set(msg ? `Google sign-in failed: ${msg}` : 'Google sign-in failed. Please try again.');
+      const msg = this.extractMessage(err);
+      const code = err?.code != null ? ` (code ${err.code})` : '';
+      this.error.set(msg ? `Google sign-in failed: ${msg}${code}` : `Google sign-in failed${code}. Please try again.`);
+      this.reportAuthError('google', err);
       this.loading.set(false);
       this.googleLoading.set(false);
     }
@@ -89,13 +94,30 @@ export class AuthModalComponent {
       if (code === 'ERR_CANCELED' || code === '1001' || /cancel/i.test(String(err?.message ?? ''))) {
         this.error.set(null);
       } else {
-        const msg = err?.error?.message ?? err?.error_description ?? err?.message;
-        this.error.set(msg ? `Apple sign-in failed: ${msg}` : 'Apple sign-in failed. Please try again.');
+        const msg = this.extractMessage(err);
+        const codeSuffix = err?.code != null ? ` (code ${err.code})` : '';
+        this.error.set(msg ? `Apple sign-in failed: ${msg}${codeSuffix}` : `Apple sign-in failed${codeSuffix}. Please try again.`);
+        this.reportAuthError('apple', err);
       }
     } finally {
       this.loading.set(false);
       this.appleLoading.set(false);
     }
+  }
+
+  private extractMessage(err: any): string | undefined {
+    return err?.error?.message ?? err?.error_description ?? err?.message;
+  }
+
+  private reportAuthError(provider: 'email' | 'google' | 'apple', err: any): void {
+    const msg = this.extractMessage(err) ?? 'unknown';
+    const code = err?.code ?? err?.status ?? err?.error?.code ?? 'none';
+    void this.crashlytics.recordException(new Error(`auth(${provider}) failed: ${msg}`), {
+      provider,
+      auth_error_code: String(code),
+      auth_error_message: String(msg).slice(0, 200),
+      platform: this.platform.isNative ? (this.platform.isIos ? 'ios' : 'android') : 'web',
+    });
   }
 
   @HostListener('document:keydown.escape')


### PR DESCRIPTION
## Why

"Google sign-in failed: Something went wrong" on Android with **no clue what's actually wrong**:
- Railway shows nothing (auth is client-side, never hits the backend).
- Crashlytics shows nothing (the catch only sets a toast and re-renders the modal).
- The generic 'Something went wrong' string is just `err.message` from the `@southdevs/capacitor-google-auth` SDK — useless.

## What

- `AuthModalComponent` now calls `CrashlyticsService.recordException` for every email / Google / Apple failure (still skipping user cancellations) with custom keys: `provider`, `auth_error_code`, `auth_error_message`, `platform`.
- Google + Apple error toasts now append the numeric **error code** (e.g. 'code 10' = `DEVELOPER_ERROR` / SHA-1 mismatch in Google Play Services) so users can read it back to us even if Crashlytics is unavailable.

## Self-resolves the version-visibility issue

These will be the first non-fatals from the new builds, so 1.5(6) / 1.6 will start appearing in the Firebase console version dropdown.

## Probable cause of the user-reported error

For native Google sign-in on Android, 'Something went wrong' usually means one of:
1. **SHA-1 fingerprint mismatch** — the SHA of the APK signing cert isn't registered on the OAuth Web Client in Google Cloud Console.
2. **Wrong / missing `serverClientId`** — must be the **Web** client id, not the Android one (we already pass the Web id).
3. **Google Play Services missing or outdated** on the device.

After this PR ships, the next failure will tell us which one (the Crashlytics issue will have the code attached).