### PR TITLE
chore(android): refresh google-services.json from Firebase

### DIFF
--- a/frontend/android/app/google-services.json
+++ b/frontend/android/app/google-services.json
@@ -53,6 +53,14 @@
             {
               "client_id": "215249721443-drub176d1u1jha7pl9uvvuo596uspbo5.apps.googleusercontent.com",
               "client_type": 3
+            },
+            {
+              "client_id": "215249721443-dldujn3efff1onlmft2u30ikih89q294.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.stepovr.app",
+                "app_store_id": "6762849377"
+              }
             }
           ]
         }


### PR DESCRIPTION
Latest copy from Firebase Console. Only diff is an additional iOS OAuth client entry — no behavioural change. Sync only.