### PR TITLE
fix(android): use Web OAuth client id for Google sign-in audience

### DIFF
--- a/frontend/capacitor.config.ts
+++ b/frontend/capacitor.config.ts
@@ -17,9 +17,15 @@ const config: CapacitorConfig = {
     },
     GoogleAuth: {
       scopes: ['profile', 'email'],
-      // iOS OAuth client ID (platform = iOS in Google Cloud Console)
-      clientId: '215249721443-dldujn3efff1onlmft2u30ikih89q294.apps.googleusercontent.com',
-      // Web OAuth client ID — used by Android as the audience for the id_token
+      // iOS OAuth client ID (type=2 in Google Cloud — registered with iOS bundle id)
+      iosClientId: '215249721443-dldujn3efff1onlmft2u30ikih89q294.apps.googleusercontent.com',
+      // Android uses the Web OAuth client as the audience for requestIdToken()
+      // because the @southdevs/capacitor-google-auth plugin's initialize() reads
+      // androidClientId → clientId → R.string.server_client_id, in that order.
+      // The Web client has no SHA fingerprint, but it's what Supabase validates.
+      androidClientId: '215249721443-drub176d1u1jha7pl9uvvuo596uspbo5.apps.googleusercontent.com',
+      // Same Web client id, also exposed via the dedicated serverClientId field
+      // for the plugin paths that read it directly.
       serverClientId: '215249721443-drub176d1u1jha7pl9uvvuo596uspbo5.apps.googleusercontent.com',
       forceCodeForRefreshToken: true,
     },


### PR DESCRIPTION
## Symptom

Google sign-in on Android failed with a generic 'Something went wrong' message **before** the account picker opened.

## Root cause

`@southdevs/capacitor-google-auth` plugin's Android `initialize()` resolves the OAuth client id in this order:

```
androidClientId  →  clientId  →  R.string.server_client_id
```

Our `capacitor.config.ts` had `clientId` set to the **iOS** OAuth client (a `type=2` client registered against the iOS bundle id, with no Android SHA). So on Android `initialize()` handed Google Play Services an iOS client id, which GPS rejected with `DEVELOPER_ERROR` (code 10) before showing the picker. The `serverClientId` field is read in some other plugin paths but **not** by `initialize()`.

## Fix

Split into platform-specific fields:

- `iosClientId` — type=2 (iOS bundle id)
- `androidClientId` — Web OAuth client (type=3), what `initialize()` uses
- `serverClientId` — same Web client, for the paths that read it directly

The Web client's id_token is also what Supabase validates as the audience, so the native id_token's `aud` claim now aligns with what the backend expects.

## Test plan

`npm run cap:build && npx cap run android` → tap 'Continue with Google' → account picker should now open.